### PR TITLE
Add support for extended prefix maps

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1-dev
+current_version = 0.4.0-dev
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<release>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = f"{date.today().year}, Charles Tapley Hoyt"
 author = "Charles Tapley Hoyt"
 
 # The full version, including alpha/beta/rc tags.
-release = "0.3.1-dev"
+release = "0.4.0-dev"
 
 # The short X.Y version.
 parsed_version = re.match(

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ##########################
 [metadata]
 name = curies
-version = 0.3.1-dev
+version = 0.4.0-dev
 description = Idiomatic conversion between URIs and compact URIs (CURIEs).
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,8 @@ tests =
     coverage
 pandas =
     pandas
+bioregistry =
+    bioregistry>=0.5.136
 docs =
     sphinx
     sphinx-rtd-theme

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -191,11 +191,22 @@ class Converter:
 
     @classmethod
     def from_extended_prefix_map_url(cls, url: str, **kwargs) -> "Converter":
-        """Get a converter from a remote JSON file containing records.
+        """Get a converter from a remote JSON file containing an extended prefix map.
 
         :param url: The URL of a JSON file containiing dictionaries corresponding to the :class:`Record` schema
         :param kwargs: Keyword arguments to pass to the parent class's init
         :returns: A converter
+
+        An extended prefix map is a list of dictionaries containing four keys:
+
+        1. A ``prefix`` string
+        2. A ``uri_prefix`` string
+        3. An optional list of strings ``prefix_synonyms``
+        4. An optional list of strings ``uri_prefix_synonyms``
+
+        Across the whole list of dictionaries, there should be uniqueness within
+        the union of all ``prefix`` and ``prefix_synonyms`` as well as uniqueness
+        within the union of all ``uri_prefix`` and ``uri_prefix_synonyms``.
         """
         res = requests.get(url)
         res.raise_for_status()
@@ -209,6 +220,17 @@ class Converter:
             get converted into record objects
         :param kwargs: Keyword arguments to pass to the parent class's init
         :returns: A converter
+
+        An extended prefix map is a list of dictionaries containing four keys:
+
+        1. A ``prefix`` string
+        2. A ``uri_prefix`` string
+        3. An optional list of strings ``prefix_synonyms``
+        4. An optional list of strings ``uri_prefix_synonyms``
+
+        Across the whole list of dictionaries, there should be uniqueness within
+        the union of all ``prefix`` and ``prefix_synonyms`` as well as uniqueness
+        within the union of all ``uri_prefix`` and ``uri_prefix_synonyms``.
         """
         records = [record if isinstance(record, Record) else Record(**record) for record in records]
         return cls(records=records, **kwargs)

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -190,6 +190,30 @@ class Converter:
         self.trie = StringTrie(self.reverse_prefix_map)
 
     @classmethod
+    def from_extended_prefix_map_url(cls, url: str, **kwargs) -> "Converter":
+        """Get a converter from a remote JSON file containing records.
+
+        :param url: The URL of a JSON file containiing dictionaries corresponding to the :class:`Record` schema
+        :param kwargs: Keyword arguments to pass to the parent class's init
+        :returns: A converter
+        """
+        res = requests.get(url)
+        res.raise_for_status()
+        return cls.from_extended_prefix_map(res.json(), **kwargs)
+
+    @classmethod
+    def from_extended_prefix_map(cls, records, **kwargs) -> "Converter":
+        """Get a converter from a list of dictionaries by creating records out of them.
+
+        :param records: An iterable of :class:`Record` objects or dictionaries that will
+            get converted into record objects
+        :param kwargs: Keyword arguments to pass to the parent class's init
+        :returns: A converter
+        """
+        records = [record if isinstance(record, Record) else Record(**record) for record in records]
+        return cls(records=records, **kwargs)
+
+    @classmethod
     def from_priority_prefix_map(cls, data: Mapping[str, List[str]], **kwargs) -> "Converter":
         """Get a converter from a priority prefix map.
 

--- a/src/curies/sources.py
+++ b/src/curies/sources.py
@@ -12,6 +12,10 @@ __all__ = [
     "get_bioregistry_converter",
 ]
 
+BIOREGISTRY_CONTEXTS = (
+    "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts"
+)
+
 
 def get_obo_converter() -> Converter:
     """Get the latest OBO Foundry context."""
@@ -46,8 +50,5 @@ def get_go_converter() -> Converter:
 
 def get_bioregistry_converter() -> Converter:
     """Get the latest Bioregistry context."""
-    url = (
-        "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/"
-        "exports/contexts/reverse_prefix_map.json"
-    )
-    return Converter.from_reverse_prefix_map_url(url)
+    url = f"{BIOREGISTRY_CONTEXTS}/bioregistry.epm.json"
+    return Converter.from_extended_prefix_map_url(url)

--- a/src/curies/sources.py
+++ b/src/curies/sources.py
@@ -53,7 +53,7 @@ def get_bioregistry_converter(web: bool = False, **kwargs) -> Converter:
     if not web:
         try:
             import bioregistry
-        except ImportError:
+        except ImportError:  # pragma: no cover
             pass
         else:
             return Converter.from_extended_prefix_map(bioregistry.manager.get_curies_records())

--- a/src/curies/sources.py
+++ b/src/curies/sources.py
@@ -48,7 +48,14 @@ def get_go_converter() -> Converter:
     return get_prefixcommons_converter("go_context")
 
 
-def get_bioregistry_converter() -> Converter:
+def get_bioregistry_converter(web: bool = False, **kwargs) -> Converter:
     """Get the latest Bioregistry context."""
+    if not web:
+        try:
+            import bioregistry
+        except ImportError:
+            pass
+        else:
+            return Converter.from_extended_prefix_map(bioregistry.manager.get_curies_records())
     url = f"{BIOREGISTRY_CONTEXTS}/bioregistry.epm.json"
-    return Converter.from_extended_prefix_map_url(url)
+    return Converter.from_extended_prefix_map_url(url, **kwargs)

--- a/src/curies/version.py
+++ b/src/curies/version.py
@@ -7,7 +7,7 @@ __all__ = [
     "get_version",
 ]
 
-VERSION = "0.3.1-dev"
+VERSION = "0.4.0-dev"
 
 
 def get_version():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,11 +2,13 @@
 
 """Trivial version test."""
 
+import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pandas as pd
+from bioregistry.export.prefix_maps import EXTENDED_PREFIX_MAP_PATH
 
 from curies.api import Converter, DuplicatePrefixes, DuplicateURIPrefixes, Record, chain
 from curies.sources import (
@@ -101,9 +103,9 @@ class TestConverter(unittest.TestCase):
         )
         self.assertIn("rdf", semweb_converter.prefix_map)
 
-        bioregistry_converter = get_bioregistry_converter(web=True)
-        self.assertIn("chebi", bioregistry_converter.prefix_map)
-        self.assertNotIn("CHEBI", bioregistry_converter.prefix_map)
+        for web in [True, False]:
+            bioregistry_converter = get_bioregistry_converter(web=web)
+            self.assert_bioregistry_converter(bioregistry_converter)
 
         c = Converter.from_reverse_prefix_map_url(f"{BIOREGISTRY_CONTEXTS}/bioregistry.rpm.json")
         self.assertIn("chebi", c.prefix_map)
@@ -120,6 +122,33 @@ class TestConverter(unittest.TestCase):
         go_converter = get_go_converter()
         self.assertIn("CHEBI", go_converter.prefix_map)
         self.assertNotIn("chebi", go_converter.prefix_map)
+
+    def assert_bioregistry_converter(self, converter: Converter) -> None:
+        """Assert the bioregistry converter has the right stuff in it."""
+        records = {records.prefix: records for records in converter.records}
+        self.assertIn("chebi", records)
+        record = records["chebi"]
+        self.assertIsInstance(record, Record)
+        self.assertEqual("chebi", record.prefix)
+        self.assertIn("CHEBI", record.prefix_synonyms)
+        self.assertIn("ChEBI", record.prefix_synonyms)
+
+        self.assertIn("chebi", converter.prefix_map)
+        # Synonyms that are non-conflicting also get added
+        self.assertIn("CHEBI", converter.prefix_map)
+        chebi_uri = converter.prefix_map["chebi"]
+        self.assertIn(chebi_uri, converter.reverse_prefix_map)
+        self.assertEqual("chebi", converter.reverse_prefix_map[chebi_uri])
+
+    @unittest.skipUnless(
+        EXTENDED_PREFIX_MAP_PATH.is_file(),
+        reason="missing local, editable installation of the Bioregistry",
+    )
+    def test_bioregistry_editable(self):
+        """Test loading the bioregistry extended prefix map locally."""
+        records = json.loads(EXTENDED_PREFIX_MAP_PATH.read_text())
+        converter = Converter.from_extended_prefix_map(records)
+        self.assert_bioregistry_converter(converter)
 
     def test_reverse_constructor(self):
         """Test constructing from a reverse prefix map."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from curies.api import Converter, DuplicatePrefixes, DuplicateURIPrefixes, Record, chain
 from curies.sources import (
+    BIOREGISTRY_CONTEXTS,
     get_bioregistry_converter,
     get_go_converter,
     get_monarch_converter,
@@ -104,6 +105,10 @@ class TestConverter(unittest.TestCase):
         self.assertIn("chebi", bioregistry_converter.prefix_map)
         self.assertNotIn("CHEBI", bioregistry_converter.prefix_map)
 
+        c = Converter.from_reverse_prefix_map_url(f"{BIOREGISTRY_CONTEXTS}/bioregistry.rpm.json")
+        self.assertIn("chebi", c.prefix_map)
+        self.assertNotIn("CHEBI", c.prefix_map)
+
         obo_converter = get_obo_converter()
         self.assertIn("CHEBI", obo_converter.prefix_map)
         self.assertNotIn("chebi", obo_converter.prefix_map)
@@ -116,7 +121,7 @@ class TestConverter(unittest.TestCase):
         self.assertIn("CHEBI", go_converter.prefix_map)
         self.assertNotIn("chebi", go_converter.prefix_map)
 
-    def test_reverse_constuctor(self):
+    def test_reverse_constructor(self):
         """Test constructing from a reverse prefix map."""
         converter = Converter.from_reverse_prefix_map(
             {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,7 +101,7 @@ class TestConverter(unittest.TestCase):
         )
         self.assertIn("rdf", semweb_converter.prefix_map)
 
-        bioregistry_converter = get_bioregistry_converter()
+        bioregistry_converter = get_bioregistry_converter(web=True)
         self.assertIn("chebi", bioregistry_converter.prefix_map)
         self.assertNotIn("CHEBI", bioregistry_converter.prefix_map)
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ extras =
     # See the [options.extras_require] entry in setup.cfg for "tests"
     tests
     pandas
+    bioregistry
 
 [testenv:doctests]
 commands =


### PR DESCRIPTION
As a follow-up to https://github.com/biopragmatics/bioregistry/pull/631, this PR adds support for "extended prefix maps" to the `curies` package. CC @caufieldjh

## What's an Extended Prefix Map

An extended prefix map is a list of dictionaries containing four keys:

1. A required ``prefix`` string
2. A required ``uri_prefix`` string
3. An optional list of strings ``prefix_synonyms``
4. An optional list of strings ``uri_prefix_synonyms``

Across the whole list of dictionaries, there should be uniqueness within the union of all ``prefix`` and ``prefix_synonyms`` as well as uniqueness within the union of all ``uri_prefix`` and ``uri_prefix_synonyms``.

An example extended prefix map can be found at https://github.com/biopragmatics/bioregistry/blob/main/exports/contexts/bioregistry.epm.json.

## New Code

```python
from curies import Converter

url = "https://github.com/biopragmatics/bioregistry/raw/main/exports/contexts/bioregistry.epm.json"
converter = Converter.from_extended_prefix_map_url(url)

>>> converter.expand("chebi:24867")
'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24867'

# Prefix synonyms also work!
>>> converter.expand("CHEBI:24867")
'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24867'

>>> converter.compress("https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:24867")
'chebi:24867'

# URI prefix synonyms also work!
>>> converter.compress("http://purl.obolibrary.org/obo/CHEBI_24867")
'chebi:24867'
```