### PR TITLE
Add support for `prefixmaps` context object

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ pandas =
 bioregistry =
     bioregistry>=0.5.136
 prefixmaps =
-    prefixmaps
+    prefixmaps>=0.1.4
 docs =
     sphinx
     sphinx-rtd-theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,8 @@ pandas =
     pandas
 bioregistry =
     bioregistry>=0.5.136
+prefixmaps =
+    prefixmaps
 docs =
     sphinx
     sphinx-rtd-theme

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -754,12 +754,3 @@ def chain(converters: Sequence[Converter], case_sensitive: bool = True) -> Conve
             for key, (prefix, uri_prefix) in key_to_pair.items()
         ]
     )
-
-
-if __name__ == "__main__":
-    from prefixmaps import load_context
-
-    context = load_context("bioportal")
-    for e in context.prefix_expansions:
-        if e.prefix in {"INVERSEROLES", "ISO-15926-2_2003"}:
-            print(e)

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -26,7 +26,7 @@ from pytrie import StringTrie
 
 if TYPE_CHECKING:  # pragma: no cover
     import pandas
-    import prefixmaps.datamodel
+    import prefixmaps
 
 __all__ = [
     "Converter",
@@ -466,8 +466,8 @@ class Converter:
         return cls.from_jsonld_url(url)
 
     @classmethod
-    def from_linkml_context(cls, context: "prefixmaps.datamodel.Context", **kwargs) -> "Converter":
-        """Get a converter from the :class:`prefixmaps` package.
+    def from_linkml_context(cls, context: "prefixmaps.Context", **kwargs) -> "Converter":
+        """Get a converter from the :mod:`prefixmaps` package.
 
         :param context: The context object
         :param kwargs: Keyword arguments to pass to the constructor
@@ -486,8 +486,7 @@ class Converter:
         >>> converter.expand("FlyBase:FBgn123")
         'http://identifiers.org/fb/FBgn123'
         """
-        reverse_prefix_map = {}
-        prefix_map = {}
+        prefix_map, reverse_prefix_map = {}, {}
         for expansion in context.prefix_expansions:
             if expansion.canonical():
                 reverse_prefix_map[expansion.namespace] = expansion.prefix
@@ -506,9 +505,9 @@ class Converter:
         records = [
             Record(
                 prefix=prefix,
-                prefix_synonyms=sorted(prefix_synonyms[expansion.prefix]),
+                prefix_synonyms=sorted(prefix_synonyms[prefix]),
                 uri_prefix=uri_prefix,
-                uri_prefix_synonyms=sorted(uri_prefix_synonyms[expansion.prefix]),
+                uri_prefix_synonyms=sorted(uri_prefix_synonyms[prefix]),
             )
             for prefix, uri_prefix in prefix_map.items()
         ]

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -25,6 +25,7 @@ from pytrie import StringTrie
 
 if TYPE_CHECKING:  # pragma: no cover
     import pandas
+    import prefixmaps.datamodel
 
 __all__ = [
     "Converter",
@@ -460,6 +461,29 @@ class Converter:
         rest = "/".join(path)
         url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{rest}"
         return cls.from_jsonld_url(url)
+
+    @classmethod
+    def from_linkml_context(self, context: "prefixmaps.datamodel.Context") -> "Converter":
+        """Get a converter from the :class:`prefixmaps` package.
+
+        :param context: The context object
+        :return:
+            A converter
+
+        >>> from prefixmaps import load_context
+        >>> context = load_context("obo")
+        >>> converter = Converter.from_linkml_context(context)
+        >>> converter.expand("CHEBI:1")
+        'http://purl.obolibrary.org/obo/CHEBI_1'
+        >>> converter.expand("GEO:1")
+        'http://purl.obolibrary.org/obo/GEO_1'
+        >>> converter.expand("owl:Class")
+        'http://www.w3.org/2002/07/owl#Class'
+        >>> converter.expand("FlyBase:FBgn123")
+        'http://identifiers.org/fb/FBgn123'
+        """
+        # TODO improve data structure for this
+        return cls.from_prefix_map(context.as_dict())
 
     def get_prefixes(self) -> Set[str]:
         """Get the set of prefixes covered by this converter."""

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -4,7 +4,6 @@
 
 import csv
 import itertools as itt
-import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -35,8 +34,6 @@ __all__ = [
     "DuplicateURIPrefixes",
     "chain",
 ]
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pandas as pd
-from bioregistry.export.prefix_maps import EXTENDED_PREFIX_MAP_PATH
 
 from curies.api import Converter, DuplicatePrefixes, DuplicateURIPrefixes, Record, chain
 from curies.sources import (
@@ -24,6 +23,11 @@ try:
     import prefixmaps
 except ImportError:
     prefixmaps = None
+
+try:
+    from bioregistry.export.prefix_maps import EXTENDED_PREFIX_MAP_PATH
+except:
+    EXTENDED_PREFIX_MAP_PATH = None
 
 
 class TestConverter(unittest.TestCase):
@@ -146,7 +150,7 @@ class TestConverter(unittest.TestCase):
         self.assertEqual("chebi", converter.reverse_prefix_map[chebi_uri])
 
     @unittest.skipUnless(
-        EXTENDED_PREFIX_MAP_PATH.is_file(),
+        isinstance(EXTENDED_PREFIX_MAP_PATH, Path) and EXTENDED_PREFIX_MAP_PATH.is_file(),
         reason="missing local, editable installation of the Bioregistry",
     )
     def test_bioregistry_editable(self):
@@ -312,12 +316,10 @@ class TestLinkML(unittest.TestCase):
             "WIKIPATHWAYS",
             converter.reverse_prefix_map["http://vocabularies.wikipathways.org/wp#"],
         )
-        self.assertIn(
-            "http://vocabularies.wikipathways.org/wpTypes#", set(converter.reverse_prefix_map)
-        )
+        self.assertIn("http://vocabularies.wikipathways.org/wp#", set(converter.reverse_prefix_map))
         self.assertEqual(
             "WIKIPATHWAYS",
-            converter.reverse_prefix_map["http://vocabularies.wikipathways.org/wpTypes#"],
+            converter.reverse_prefix_map["http://vocabularies.wikipathways.org/wp#"],
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,7 @@ except ImportError:
 
 try:
     from bioregistry.export.prefix_maps import EXTENDED_PREFIX_MAP_PATH
-except:
+except ImportError:
     EXTENDED_PREFIX_MAP_PATH = None
 
 
@@ -311,10 +311,7 @@ class TestLinkML(unittest.TestCase):
         uri_prefix_2 = "http://vocabularies.wikipathways.org/wpTypes#"
 
         context = prefixmaps.load_context("bioportal")
-        context_namespaces = {
-            expansion.namespace
-            for expansion in context.prefix_expansions
-        }
+        context_namespaces = {expansion.namespace for expansion in context.prefix_expansions}
         self.assertIn(uri_prefix_1, context_namespaces)
         self.assertIn(uri_prefix_2, context_namespaces)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -306,21 +306,32 @@ class TestLinkML(unittest.TestCase):
         """Test loading prefixmaps content."""
         import prefixmaps
 
+        prefix = "WIKIPATHWAYS"
+        uri_prefix_1 = "http://vocabularies.wikipathways.org/wp#"
+        uri_prefix_2 = "http://vocabularies.wikipathways.org/wpTypes#"
+
         context = prefixmaps.load_context("bioportal")
+        context_namespaces = {
+            expansion.namespace
+            for expansion in context.prefix_expansions
+        }
+        self.assertIn(uri_prefix_1, context_namespaces)
+        self.assertIn(uri_prefix_2, context_namespaces)
+
         converter = Converter.from_linkml_context(context)
         # bioportal,WIKIPATHWAYS,http://vocabularies.wikipathways.org/wp#,canonical
-        # bioportal,WIKIPATHWAYS,http://vocabularies.wikipathways.org/wpTypes#,prefix_alias
-        self.assertIn("WIKIPATHWAYS", converter.prefix_map)
-        self.assertIn("http://vocabularies.wikipathways.org/wp#", set(converter.reverse_prefix_map))
-        self.assertEqual(
-            "WIKIPATHWAYS",
-            converter.reverse_prefix_map["http://vocabularies.wikipathways.org/wp#"],
-        )
-        self.assertIn("http://vocabularies.wikipathways.org/wp#", set(converter.reverse_prefix_map))
-        self.assertEqual(
-            "WIKIPATHWAYS",
-            converter.reverse_prefix_map["http://vocabularies.wikipathways.org/wp#"],
-        )
+        # bioportal,WIKIPATHWAYS,,prefix_alias
+
+        # prefix map checks
+        self.assertIn(prefix, converter.prefix_map)
+        self.assertEqual(uri_prefix_1, converter.prefix_map[prefix])
+        self.assertNotIn(uri_prefix_2, converter.prefix_map.values())
+
+        # Reverse prefix map checks
+        self.assertIn(uri_prefix_1, converter.reverse_prefix_map)
+        self.assertIn(uri_prefix_2, converter.reverse_prefix_map)
+        self.assertEqual(prefix, converter.reverse_prefix_map[uri_prefix_1])
+        self.assertEqual(prefix, converter.reverse_prefix_map[uri_prefix_2])
 
 
 class TestVersion(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,8 @@ description = Build the documentation locally.
 extras =
     docs
     pandas
+    bioregistry
+    prefixmaps
 commands =
     python -m sphinx -W -b html -d docs/build/doctrees docs/source docs/build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ extras =
     tests
     pandas
     bioregistry
+    prefixmaps
 
 [testenv:doctests]
 commands =


### PR DESCRIPTION
This implements a smarter way of generating a converter that takes advantage of things besides the canonical records.

```python
from prefixmaps import load_context
from curies import Converter

context = load_context("obo")
converter = Converter.from_linkml_context(context)

>>>converter.expand("CHEBI:1")
'http://purl.obolibrary.org/obo/CHEBI_1'
```

## Blockers

- [x] https://github.com/linkml/prefixmaps/issues/11. The issue here is that the `prefixmaps` package doesn't really provide any guarantees about bijectivity. In the mean time, we can just promote one conflicting prefix to be "canonical"