### PR TITLE
Add RDFLib functionality

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,3 +19,4 @@ python:
         - pandas
         - flask
         - fastapi
+        - rdflib

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,8 @@ flask =
 fastapi =
     fastapi
     httpx
+rdflib =
+    rdflib
 docs =
     sphinx
     sphinx-rtd-theme

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -538,10 +538,19 @@ class Converter:
         :param kwargs: Keyword arguments to pass to :meth:`from_prefix_map`
         :return: A converter
 
+        In the following example, a :class:`rdflib.Graph` is created, a namespace
+        is bound to it, then a converter is made:
+
         >>> import rdflib, curies
         >>> graph = rdflib.Graph()
         >>> graph.bind("hgnc", "https://bioregistry.io/hgnc:")
         >>> converter = curies.Converter.from_rdflib(graph)
+        >>> converter.expand("hgnc:1234")
+        'https://bioregistry.io/hgnc:1234'
+
+        This also works if you directly start with a :class:`rdflib.namespace.NamespaceManager`:
+
+        >>> converter = curies.Converter.from_rdflib(graph.namespace_manager)
         >>> converter.expand("hgnc:1234")
         'https://bioregistry.io/hgnc:1234'
         """

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -532,9 +532,9 @@ class Converter:
         graph_or_manager: Union["rdflib.Graph", "rdflib.namespace.NamespaceManager"],
         **kwargs: Any,
     ) -> "Converter":
-        """Get a converter from an RDFlib graph or namespace manager.
+        """Get a converter from an RDFLib graph or namespace manager.
 
-        :param graph_or_manager: A RDFlib graph or manager object
+        :param graph_or_manager: A RDFLib graph or manager object
         :param kwargs: Keyword arguments to pass to :meth:`from_prefix_map`
         :return: A converter
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -545,10 +545,8 @@ class Converter:
         >>> converter.expand("hgnc:1234")
         'https://bioregistry.io/hgnc:1234'
         """
-        import rdflib
-
-        if isinstance(graph_or_manager, rdflib.Graph):
-            graph_or_manager = graph_or_manager.namespace_manager
+        # it's required to stringify namespace since it's a rdflib.URIRef
+        # object, which acts funny if not coerced into a string
         prefix_map = {prefix: str(namespace) for prefix, namespace in graph_or_manager.namespaces()}
         return cls.from_prefix_map(prefix_map, **kwargs)
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -32,6 +32,7 @@ from pytrie import StringTrie
 
 if TYPE_CHECKING:  # pragma: no cover
     import pandas
+    import rdflib
 
 __all__ = [
     "Converter",
@@ -524,6 +525,32 @@ class Converter:
         rest = "/".join(path)
         url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{rest}"
         return cls.from_jsonld(url)
+
+    @classmethod
+    def from_rdflib(
+        cls,
+        graph_or_manager: Union["rdflib.Graph", "rdflib.namespace.NamespaceManager"],
+        **kwargs: Any,
+    ) -> "Converter":
+        """Get a converter from an RDFlib graph or namespace manager.
+
+        :param graph_or_manager: A RDFlib graph or manager object
+        :param kwargs: Keyword arguments to pass to :meth:`from_prefix_map`
+        :return: A converter
+
+        >>> import rdflib, curies
+        >>> graph = rdflib.Graph()
+        >>> graph.bind("hgnc", "https://bioregistry.io/hgnc:")
+        >>> converter = curies.Converter.from_rdflib(graph)
+        >>> converter.expand("hgnc:1234")
+        'https://bioregistry.io/hgnc:1234'
+        """
+        import rdflib
+
+        if isinstance(graph_or_manager, rdflib.Graph):
+            graph_or_manager = graph_or_manager.namespace_manager
+        prefix_map = {prefix: str(namespace) for prefix, namespace in graph_or_manager.namespaces()}
+        return cls.from_prefix_map(prefix_map, **kwargs)
 
     def get_prefixes(self) -> Set[str]:
         """Get the set of prefixes covered by this converter."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pandas as pd
+import rdflib
 from bioregistry.export.prefix_maps import EXTENDED_PREFIX_MAP_PATH
 
 from curies.api import Converter, DuplicatePrefixes, DuplicateURIPrefixes, Record, chain
@@ -342,6 +343,14 @@ class TestConverter(unittest.TestCase):
             )
         with self.assertRaises(ValueError):
             converter.add_prefix("...", "...", prefix_synonyms=["GO"])
+
+    def test_rdflib(self):
+        """Test parsing a converter from an RDFLib object."""
+        graph = rdflib.Graph()
+        for prefix, uri_prefix in self.simple_obo_prefix_map.items():
+            graph.bind(prefix, uri_prefix)
+        converter = Converter.from_rdflib(graph)
+        self._assert_convert(converter)
 
 
 class TestVersion(unittest.TestCase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -352,6 +352,9 @@ class TestConverter(unittest.TestCase):
         converter = Converter.from_rdflib(graph)
         self._assert_convert(converter)
 
+        converter_2 = Converter.from_rdflib(graph.namespace_manager)
+        self._assert_convert(converter_2)
+
 
 class TestVersion(unittest.TestCase):
     """Trivially test a version."""

--- a/tox.ini
+++ b/tox.ini
@@ -136,6 +136,7 @@ extras =
     pandas
     flask
     fastapi
+    rdflib
 commands =
     python -m sphinx -W -b html -d docs/build/doctrees docs/source docs/build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ extras =
     bioregistry
     flask
     fastapi
+    rdflib
 
 [testenv:doctests]
 commands =


### PR DESCRIPTION
This PR adds the ability to extract a `curies.Converter` from an RDFLib object

```python
import rdflib, curies

# Build an RDFLib graph and populate its namespace manager
graph = rdflib.Graph()
graph.bind("hgnc", "https://bioregistry.io/hgnc:")

# Convert to a converter
converter = curies.Converter.from_rdflib(graph)
converter.expand("hgnc:1234")
assert converter.expand("hgnc:1234") == "https://bioregistry.io/hgnc:"

# This also works if you have a namespace manager directly
converter = curies.Converter.from_rdflib(graph.namespace_manager)
assert converter.expand("hgnc:1234") == "https://bioregistry.io/hgnc:"
