### PR TITLE
Add functionality for standardizing CURIEs

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -242,6 +242,8 @@ class Converter:
         """Append a record to the converter."""
         self._check_record(record)
 
+        # TODO test this later
+        # self.records.append(record)
         self.prefix_map[record.prefix] = record.uri_prefix
         for prefix_synonym in record.prefix_synonyms:
             self.prefix_map[prefix_synonym] = record.uri_prefix

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -193,6 +193,21 @@ class TestConverter(unittest.TestCase):
             converter.compress("https://www.ebi.ac.uk/chebi/searchId.do?chebiId=138488"),
         )
 
+    def test_standardize_curie(self):
+        """Test standardize CURIE."""
+        converter = Converter.from_extended_prefix_map(
+            [
+                Record(
+                    prefix="CHEBI",
+                    prefix_synonyms=["chebi"],
+                    uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
+                ),
+            ]
+        )
+        self.assertEqual("CHEBI:138488", converter.standardize_curie("chebi:138488"))
+        self.assertEqual("CHEBI:138488", converter.standardize_curie("CHEBI:138488"))
+        self.assertIsNone(converter.standardize_curie("NOPE:NOPE"))
+
     def test_combine(self):
         """Test chaining converters."""
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR implements functionality for standardizing CURIEs based on prefix synonyms available within a `curies.Converter`.

```python
from curies import Converter, Record
converter = Converter.from_extended_prefix_map([
    Record(
        prefix="CHEBI", 
        prefix_synonyms=["chebi"], 
        uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
    ),
])

# Non-standard CURIE gets fixed
>>> converter.standardize_curie("chebi:138488")
'CHEBI:138488'

# Standard CURIE is returned
>>> converter.standardize_curie("CHEBI:138488")
'CHEBI:138488'

# Unregistered prefix returns None
>>> converter.standardize_curie("NOPE:NOPE") is None
True
```

cc @matentzn