### PR TITLE
Implement URI standardization

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -711,10 +711,11 @@ class Converter:
         >>> converter.standardize_uri("NOPE") is None
         True
         """
-        curie = self.compress(uri)
-        if curie is None:
+        prefix, identifier = self.parse_uri(uri)
+        if prefix is None or identifier is None:
             return None
-        return self.expand(uri)
+        # prefix is ensured to be in self.prefix_map because of successful parse
+        return self.prefix_map[prefix] + identifier
 
     def pd_compress(
         self,

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -663,7 +663,8 @@ class Converter:
         :returns:
             A standardized version of the CURIE in case a prefix synonym was used.
             Note that this function is idempotent, i.e., if you give an already
-            standard CURIE, it will just return it as is.
+            standard CURIE, it will just return it as is. If the CURIE can't be parsed
+            with respect to the records in the converter, None is returned.
 
         >>> from curies import Converter, Record
         >>> converter = Converter.from_extended_prefix_map([
@@ -681,6 +682,39 @@ class Converter:
         if norm_prefix is None:
             return None
         return self.format_curie(norm_prefix, identifier)
+
+    def standardize_uri(self, uri: str) -> Optional[str]:
+        """Standardize a URI.
+
+        :param uri:
+            A string representing a valid uniform resource identifier (URI)
+        :returns:
+            A standardized version of the URI in case a URI prefix synonym was used.
+            Note that this function is idempotent, i.e., if you give an already
+            standard URI, it will just return it as is. If the URI can't be parsed
+            with respect to the records in the converter, None is returned.
+
+        >>> from curies import Converter, Record
+        >>> converter = Converter.from_extended_prefix_map([
+        ...     Record(
+        ...         prefix="CHEBI",
+        ...         uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
+        ...         uri_prefix_synonyms=[
+        ...             "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:",
+        ...         ],
+        ...     ),
+        ... ])
+        >>> converter.standardize_uri("https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+        >>> converter.standardize_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+        >>> converter.standardize_uri("NOPE") is None
+        True
+        """
+        curie = self.compress(uri)
+        if curie is None:
+            return None
+        return self.expand(uri)
 
     def pd_compress(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -201,12 +201,27 @@ class TestConverter(unittest.TestCase):
                     prefix="CHEBI",
                     prefix_synonyms=["chebi"],
                     uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
+                    uri_prefix_synonyms=[
+                        "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:",
+                    ],
                 ),
             ]
         )
         self.assertEqual("CHEBI:138488", converter.standardize_curie("chebi:138488"))
         self.assertEqual("CHEBI:138488", converter.standardize_curie("CHEBI:138488"))
         self.assertIsNone(converter.standardize_curie("NOPE:NOPE"))
+
+        self.assertEqual(
+            "http://purl.obolibrary.org/obo/CHEBI_138488",
+            converter.standardize_uri(
+                "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:138488"
+            ),
+        )
+        self.assertEqual(
+            "http://purl.obolibrary.org/obo/CHEBI_138488",
+            converter.standardize_uri("http://purl.obolibrary.org/obo/CHEBI_138488"),
+        )
+        self.assertIsNone(converter.standardize_uri("NOPE"))
 
     def test_combine(self):
         """Test chaining converters."""


### PR DESCRIPTION
This PR implements URI standardization. This is relatively much more simple than #37 because of the trie data structure. CC @matentzn

```python
from curies import Converter, Record
converter = Converter.from_extended_prefix_map([
    Record(
        prefix="CHEBI",
        uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
        uri_prefix_synonyms=[
            "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:",
        ],
    ),
])

# Standardizes URI prefix synonyms
>>> converter.standardize_uri("https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:138488")
'http://purl.obolibrary.org/obo/CHEBI_138488'

# Idempotent if already standardized
>>> converter.standardize_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
'http://purl.obolibrary.org/obo/CHEBI_138488'

# Returns none if it can't be parsed
>>> converter.standardize_uri("NOPE") is None
True
```