### PR TITLE
Add functionality for generating all possible IRIs

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -682,8 +682,6 @@ class Converter:
         True
         """
         prefix, identifier = self.parse_curie(curie)
-        if prefix is None or identifier is None:
-            return None
         return self.expand_pair_all(prefix, identifier)
 
     def parse_curie(self, curie: str) -> Tuple[str, str]:


### PR DESCRIPTION
This functionality generates all possible IRIs from a given CURIE

```python
>>> priority_prefix_map = {
...     "CHEBI": [
...         "http://purl.obolibrary.org/obo/CHEBI_",
...         "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:",
...     ],
... }
>>> converter = Converter.from_priority_prefix_map(priority_prefix_map)
>>> converter.expand_all("CHEBI:138488")
['http://purl.obolibrary.org/obo/CHEBI_138488', 'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:138488']
>>> converter.expand_all("NOPE:NOPE") is None
True
```

This is useful for https://github.com/biopragmatics/bioregistry/issues/686 since you ideally want this endpoint to take an IRI and do this. That can be implemented like:

```python
import bioregistry
import rdflib
from curies import Converter

converter: Converter = bioregistry.get_default_converter()


def get_iris(iri: str) -> list[str]:
    prefix, identifier = converter.parse_uri(iri)
    if not prefix or not identifier:
        return []
    return converter.expand_pair_all(prefix, identifier)


def get_graph(
    iri: str, 
    predicate: str | rdflib.URIRef = rdflib.OWL.sameAs, 
    reflexive: bool = True,
) -> rdflib.Graph:
    subject_ref = rdflib.URIRef(iri)
    predicate_ref = predicate if isinstance(predicate, rdflib.URIRef) else rdflib.URIRef(predicate)
    graph = rdflib.Graph()
    for mapped_iri in get_iris(iri):
        obj_ref = rdflib.URIRef(mapped_iri)
        graph.add((subject_ref, predicate_ref, obj_ref))
        if reflexive:
            graph.add((obj_ref, predicate_ref, subject_ref))
    return graph
```