### PR TITLE
Add valid URI checks in mapping service graph

### DIFF
--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -151,6 +151,22 @@ class TestMappingService(unittest.TestCase):
         """
         self.assertEqual([], list(self.graph.query(sparql, processor=self.processor)))
 
+    def test_safe_expand(self):
+        """Test that expansion to invalid prefixes doesn't happen."""
+        ppm = {
+            "CHEBI": [
+                "http://purl.obolibrary.org/obo/CHEBI_",
+                "http://identifiers.org/chebi/",
+                "http://identifiers.org/chebi/nope nope:",
+            ],
+        }
+        converter = Converter.from_priority_prefix_map(ppm)
+        graph = MappingServiceGraph(converter=converter)
+        self.assertEqual(
+            {"http://purl.obolibrary.org/obo/CHEBI_1", "http://identifiers.org/chebi/1"},
+            set(map(str, graph._expand_pair_all("http://purl.obolibrary.org/obo/CHEBI_1"))),
+        )
+
 
 class ConverterMixin(unittest.TestCase):
     """A mixin that has a converter."""


### PR DESCRIPTION
Bioregistry has some synonyms that contain spaces, which currently get propagated to the `curies.Converter` instance in the Bioregistry's default `bioregistry.Manager`. This is an issue since it results in `https://bioregistry.io/<prefix>:<identifier>` variant URIs with spaces.

This PR makes sure that the ones containing spaces get filtered out. It also does some refactoring of the logic for the custom `triples()` function to streamline it and reduce code duplication.