### PR TITLE
Better handling of content types

### DIFF
--- a/src/curies/mapping_service/__init__.py
+++ b/src/curies/mapping_service/__init__.py
@@ -254,7 +254,7 @@ CONTENT_TYPE_TO_RDFLIB_FORMAT = {
 def _handle_header(header: Optional[str]) -> str:
     if not header or header == "*/*":
         return DEFAULT_CONTENT_TYPE
-    return CONTENT_TYPE_TO_RDFLIB_FORMAT[header]
+    return header
 
 
 def get_flask_mapping_blueprint(
@@ -312,7 +312,8 @@ def get_fastapi_router(
     def _resolve(request: Request, sparql: str) -> Response:
         content_type = _handle_header(request.headers.get("accept"))
         results = graph.query(sparql, processor=processor)
-        response = results.serialize(format=CONTENT_TYPE_TO_RDFLIB_FORMAT[content_type])
+        format = CONTENT_TYPE_TO_RDFLIB_FORMAT[content_type]
+        response = results.serialize(format=format)
         return Response(response, media_type=content_type)
 
     @api_router.get(route)  # type:ignore

--- a/src/curies/mapping_service/__init__.py
+++ b/src/curies/mapping_service/__init__.py
@@ -244,10 +244,10 @@ CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     # https://www.w3.org/TR/sparql11-results-csv-tsv/
     "application/sparql-results+csv": "csv",
     "text/csv": "csv",  # for compatibility
-    # Other direct RDF serializations
-    "text/turtle": "ttl",
-    "text/n3": "n3",
-    "application/ld+json": "json-ld",
+    # TODO other direct RDF serializations
+    # "text/turtle": "ttl",
+    # "text/n3": "n3",
+    # "application/ld+json": "json-ld",
 }
 
 

--- a/src/curies/mapping_service/__init__.py
+++ b/src/curies/mapping_service/__init__.py
@@ -312,8 +312,7 @@ def get_fastapi_router(
     def _resolve(request: Request, sparql: str) -> Response:
         content_type = _handle_header(request.headers.get("accept"))
         results = graph.query(sparql, processor=processor)
-        format = CONTENT_TYPE_TO_RDFLIB_FORMAT[content_type]
-        response = results.serialize(format=format)
+        response = results.serialize(format=CONTENT_TYPE_TO_RDFLIB_FORMAT[content_type])
         return Response(response, media_type=content_type)
 
     @api_router.get(route)  # type:ignore

--- a/src/curies/mapping_service/__init__.py
+++ b/src/curies/mapping_service/__init__.py
@@ -227,6 +227,7 @@ class MappingServiceGraph(Graph):  # type:ignore
                     yield subj_query, pred, obj
 
 
+DEFAULT_CONTENT_TYPE = "application/json"
 CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     # https://www.w3.org/TR/sparql11-results-json/
     "application/sparql-results+json": "json",
@@ -268,13 +269,10 @@ def get_flask_mapping_blueprint(
         sparql = (request.args if request.method == "GET" else request.json).get("query")
         if not sparql:
             return Response("Missing parameter query", 400)
-        content_type = request.headers.get("accept", "application/json")
+        content_type = request.headers.get("accept", DEFAULT_CONTENT_TYPE)
         results = graph.query(sparql, processor=processor)
         response = results.serialize(format=CONTENT_TYPE_TO_RDFLIB_FORMAT[content_type])
-        return Response(
-            response,
-            content_type=content_type,
-        )
+        return Response(response, content_type=content_type)
 
     return blueprint
 
@@ -302,7 +300,7 @@ def get_fastapi_router(
     processor = MappingServiceSPARQLProcessor(graph=graph)
 
     def _resolve(request: Request, sparql: str) -> Response:
-        content_type = request.headers.get("accept", "application/json")
+        content_type = request.headers.get("accept", DEFAULT_CONTENT_TYPE)
         results = graph.query(sparql, processor=processor)
         response = results.serialize(format=CONTENT_TYPE_TO_RDFLIB_FORMAT[content_type])
         return Response(response, media_type=content_type)

--- a/src/curies/mapping_service/__init__.py
+++ b/src/curies/mapping_service/__init__.py
@@ -104,7 +104,7 @@ Test a request using a service, e.g. with :meth:`rdflib.Graph.query`
 """
 
 import itertools as itt
-from typing import Optional, TYPE_CHECKING, Any, Collection, Iterable, List, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Collection, Iterable, List, Optional, Set, Tuple, Union, cast
 
 from rdflib import OWL, Graph, URIRef
 from rdflib.term import _is_valid_uri
@@ -227,7 +227,11 @@ class MappingServiceGraph(Graph):  # type:ignore
                     yield subj_query, pred, obj
 
 
-DEFAULT_CONTENT_TYPE = "application/json"
+#: This is default for federated queries
+DEFAULT_CONTENT_TYPE = "application/sparql-results+xml"
+
+#: A mapping from content types to the keys used for serializing
+#: in :meth:`rdflib.Graph.serialize` and other serialization functions
 CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     # https://www.w3.org/TR/sparql11-results-json/
     "application/sparql-results+json": "json",
@@ -246,8 +250,9 @@ CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     "application/ld+json": "json-ld",
 }
 
+
 def _handle_header(header: Optional[str]) -> str:
-    if header is None or header == "*/*":
+    if not header or header == "*/*":
         return DEFAULT_CONTENT_TYPE
     return CONTENT_TYPE_TO_RDFLIB_FORMAT[header]
 

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -168,6 +168,10 @@ class TestMappingService(unittest.TestCase):
         )
 
 
+def _handle_json(data):
+    return {(record["s"]["value"], record["o"]["value"]) for record in data["results"]["bindings"]}
+
+
 class ConverterMixin(unittest.TestCase):
     """A mixin that has a converter."""
 
@@ -180,11 +184,7 @@ class ConverterMixin(unittest.TestCase):
         """Test a sparql query returns expected values."""
         res = client.get(f"/sparql?query={quote(sparql)}")
         self.assertEqual(200, res.status_code, msg=f"Response: {res}\n\n{res.text}")
-        records = {
-            (record["s"]["value"], record["o"]["value"])
-            for record in json.loads(res.text)["results"]["bindings"]
-        }
-        self.assertEqual(EXPECTED, records)
+        self.assertEqual(EXPECTED, _handle_json(json.loads(res.text)))
 
 
 class TestFlaskMappingWeb(ConverterMixin):
@@ -201,10 +201,7 @@ class TestFlaskMappingWeb(ConverterMixin):
         self.assertEqual(
             200, res.status_code, msg=f"\nRequest: {res.request}\nResponse: {res}\n\n{res.json}"
         )
-        records = {
-            (record["s"]["value"], record["o"]["value"])
-            for record in json.loads(res.text)["results"]["bindings"]
-        }
+        records = _handle_json(json.loads(res.text))
         self.assertEqual(EXPECTED, records)
 
     def test_get_missing_query(self):

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -276,14 +276,18 @@ class TestFlaskMappingWeb(ConverterMixin):
     def test_get_missing_query(self):
         """Test error on missing query parameter."""
         with self.app.test_client() as client:
-            res = client.get("/sparql", headers={"accept": "application/json"})
-            self.assertEqual(400, res.status_code, msg=f"Response: {res}")
+            for content_type in sorted(CONTENT_TYPES):
+                with self.subTest(content_type=content_type):
+                    res = client.get("/sparql", headers={"accept": content_type})
+                    self.assertEqual(400, res.status_code, msg=f"Response: {res}")
 
     def test_post_missing_query(self):
         """Test error on missing query parameter."""
         with self.app.test_client() as client:
-            res = client.post("/sparql", headers={"accept": "application/json"})
-            self.assertEqual(400, res.status_code, msg=f"Response: {res}")
+            for content_type in sorted(CONTENT_TYPES):
+                with self.subTest(content_type=content_type):
+                    res = client.post("/sparql", headers={"accept": content_type})
+                    self.assertEqual(400, res.status_code, msg=f"Response: {res}")
 
     def test_get_query(self):
         """Test querying the app with GET."""
@@ -317,13 +321,17 @@ class TestFastAPIMappingApp(ConverterMixin):
 
     def test_get_missing_query(self):
         """Test error on missing query parameter."""
-        res = self.client.get("/sparql", headers={"accept": "application/json"})
-        self.assertEqual(422, res.status_code, msg=f"Response: {res}")
+        for content_type in sorted(CONTENT_TYPES):
+            with self.subTest(content_type=content_type):
+                res = self.client.get("/sparql", headers={"accept": content_type})
+                self.assertEqual(422, res.status_code, msg=f"Response: {res}")
 
     def test_post_missing_query(self):
         """Test error on missing query parameter."""
-        res = self.client.post("/sparql", headers={"accept": "application/json"})
-        self.assertEqual(422, res.status_code, msg=f"Response: {res}")
+        for content_type in sorted(CONTENT_TYPES):
+            with self.subTest(content_type=content_type):
+                res = self.client.post("/sparql", headers={"accept": content_type})
+                self.assertEqual(422, res.status_code, msg=f"Response: {res}")
 
     def test_get_query(self):
         """Test querying the app with GET."""

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -182,7 +182,7 @@ class ConverterMixin(unittest.TestCase):
 
     def assert_get_sparql_results(self, client, sparql):
         """Test a sparql query returns expected values."""
-        res = client.get(f"/sparql?query={quote(sparql)}")
+        res = client.get(f"/sparql?query={quote(sparql)}", headers={"accept": "application/json"})
         self.assertEqual(200, res.status_code, msg=f"Response: {res}\n\n{res.text}")
         self.assertEqual(EXPECTED, _handle_json(json.loads(res.text)))
 
@@ -197,7 +197,7 @@ class TestFlaskMappingWeb(ConverterMixin):
 
     def assert_post_sparql_results(self, client, sparql):
         """Test a sparql query returns expected values."""
-        res = client.post("/sparql", json={"query": sparql})
+        res = client.post("/sparql", json={"query": sparql}, headers={"accept": "application/json"})
         self.assertEqual(
             200, res.status_code, msg=f"\nRequest: {res.request}\nResponse: {res}\n\n{res.json}"
         )
@@ -207,13 +207,13 @@ class TestFlaskMappingWeb(ConverterMixin):
     def test_get_missing_query(self):
         """Test error on missing query parameter."""
         with self.app.test_client() as client:
-            res = client.get("/sparql")
+            res = client.get("/sparql", headers={"accept": "application/json"})
             self.assertEqual(400, res.status_code, msg=f"Response: {res}")
 
     def test_post_missing_query(self):
         """Test error on missing query parameter."""
         with self.app.test_client() as client:
-            res = client.post("/sparql")
+            res = client.post("/sparql", headers={"accept": "application/json"})
             self.assertEqual(400, res.status_code, msg=f"Response: {res}")
 
     def test_get_query(self):
@@ -248,26 +248,23 @@ class TestFastAPIMappingApp(ConverterMixin):
 
     def assert_post_sparql_results(self, client, sparql):
         """Test a sparql query returns expected values."""
-        res = client.post("/sparql", json={"query": sparql})
+        res = client.post("/sparql", json={"query": sparql}, headers={"accept": "application/json"})
         self.assertEqual(
             200,
             res.status_code,
             msg=f"Response: {res}",
         )
-        records = {
-            (record["s"]["value"], record["o"]["value"])
-            for record in res.json()["results"]["bindings"]
-        }
+        records = _handle_json(res.json())
         self.assertEqual(EXPECTED, records)
 
     def test_get_missing_query(self):
         """Test error on missing query parameter."""
-        res = self.client.get("/sparql")
+        res = self.client.get("/sparql", headers={"accept": "application/json"})
         self.assertEqual(422, res.status_code, msg=f"Response: {res}")
 
     def test_post_missing_query(self):
         """Test error on missing query parameter."""
-        res = self.client.post("/sparql")
+        res = self.client.post("/sparql", headers={"accept": "application/json"})
         self.assertEqual(422, res.status_code, msg=f"Response: {res}")
 
     def test_get_query(self):

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -204,21 +204,19 @@ def _handle_res_csv(res) -> Set[Tuple[str, str]]:
 #     return {(str(s), str(o)) for s, o in graph.subject_objects()}
 
 
-CONTENT_TYPES = dict(
-    [
-        ("application/sparql-results+json", _handle_res_json),
-        ("application/json", _handle_res_json),
-        ("text/json", _handle_res_json),
-        ("application/sparql-results+xml", _handle_res_xml),
-        ("application/xml", _handle_res_xml),
-        ("text/xml", _handle_res_xml),
-        ("application/sparql-results+csv", _handle_res_csv),
-        ("text/csv", _handle_res_csv),
-        # ("text/turtle", partial(_handle_res_rdf, format="ttl")),
-        # ("text/n3", partial(_handle_res_rdf, format="n3")),
-        # ("application/ld+json", partial(_handle_res_rdf, format="json-ld")),
-    ]
-)
+CONTENT_TYPES = {
+    "application/sparql-results+json": _handle_res_json,
+    "application/json": _handle_res_json,
+    "text/json": _handle_res_json,
+    "application/sparql-results+xml": _handle_res_xml,
+    "application/xml": _handle_res_xml,
+    "text/xml": _handle_res_xml,
+    "application/sparql-results+csv": _handle_res_csv,
+    "text/csv": _handle_res_csv,
+    # "text/turtle": partial(_handle_res_rdf, format="ttl"),
+    # "text/n3": partial(_handle_res_rdf, format="n3"),
+    # "application/ld+json": partial(_handle_res_rdf, format="json-ld"),
+}
 CONTENT_TYPES[""] = CONTENT_TYPES[DEFAULT_CONTENT_TYPE]
 CONTENT_TYPES["*/*"] = CONTENT_TYPES[DEFAULT_CONTENT_TYPE]
 


### PR DESCRIPTION
Closes https://github.com/biopragmatics/bioregistry/issues/775. 

This PR adds handling of headers to both the Flask and FastAPI implementations of the apps. 

- [x] Add Flask implementation
- [x] Add FastAPI implementation
- [x] Add Flask tests
- [x] Add FastAPI tests
- [ ] Should the `output` parameter be supported?

CC @vemonet. Ideally, I'd like to use https://github.com/vemonet/rdflib-endpoint and not re-implement this code, but we'll have to work through a few issues first (improving code modularity, documentation, and figuring out Flask suppot) before I can give that a try