### PR TITLE
Add explicit delimiters in web routes

### DIFF
--- a/src/curies/web.py
+++ b/src/curies/web.py
@@ -70,7 +70,7 @@ def get_flask_blueprint(converter: Converter, **kwargs: Any) -> "flask.Blueprint
 
     blueprint = Blueprint("metaresolver", __name__, **kwargs)
 
-    @blueprint.route("/<prefix>:<path:identifier>")  # type:ignore
+    @blueprint.route(f"/<prefix>{converter.delimiter}<path:identifier>")  # type:ignore
     def resolve(prefix: str, identifier: str) -> "Response":
         """Resolve a CURIE."""
         location = converter.expand_pair(prefix, identifier)
@@ -201,7 +201,7 @@ def get_fastapi_router(converter: Converter, **kwargs: Any) -> "fastapi.APIRoute
 
     api_router = APIRouter(**kwargs)
 
-    @api_router.get("/{prefix}:{identifier}")  # type:ignore
+    @api_router.get(f"/{{prefix}}{converter.delimiter}{{identifier}}")  # type:ignore
     def resolve(
         prefix: str = Path(  # noqa:B008
             title="Prefix",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,6 +3,7 @@
 """Tests for the simple web service."""
 
 import unittest
+from typing import ClassVar
 
 from fastapi.testclient import TestClient
 
@@ -13,6 +14,8 @@ from curies.web import FAILURE_CODE, get_fastapi_app, get_flask_app
 class ConverterMixin(unittest.TestCase):
     """A mixin that has a converter."""
 
+    delimiter: ClassVar[str] = ":"
+
     def setUp(self) -> None:
         """Set up the test case with a converter."""
         super().setUp()
@@ -22,7 +25,8 @@ class ConverterMixin(unittest.TestCase):
                 "MONDO": "http://purl.obolibrary.org/obo/MONDO_",
                 "GO": "http://purl.obolibrary.org/obo/GO_",
                 "OBO": "http://purl.obolibrary.org/obo/",
-            }
+            },
+            delimiter=self.delimiter,
         )
 
 
@@ -37,13 +41,25 @@ class TestFastAPI(ConverterMixin):
 
     def test_resolve_success(self):
         """Test resolution for a valid CURIE redirects properly."""
-        res = self.client.get("/GO:1234567", allow_redirects=False)
+        curie = self.converter.format_curie("GO", "1234567")
+        res = self.client.get(f"/{curie}", allow_redirects=False)
         self.assertEqual(302, res.status_code, msg=res.text)
 
     def test_resolve_failure(self):
         """Test resolution for an invalid CURIE aborts with 404."""
-        res = self.client.get("/NOPREFIX:NOIDENTIFIER", allow_redirects=False)
+        curie = self.converter.format_curie("NOPREFIX", "NOIDENTIFIER")
+        res = self.client.get(f"/{curie}", allow_redirects=False)
         self.assertEqual(FAILURE_CODE, res.status_code, msg=res.text)
+
+
+class TestFastAPISlashed(TestFastAPI):
+    """Test the FastAPI router with an alternate delimiter."""
+
+    delimiter = "/"
+
+    def test_delimiter(self):
+        """Test the delimiter."""
+        self.assertEqual("/", self.converter.delimiter)
 
 
 class TestFlaskBlueprint(ConverterMixin):
@@ -56,12 +72,24 @@ class TestFlaskBlueprint(ConverterMixin):
 
     def test_resolve_success(self):
         """Test resolution for a valid CURIE redirects properly."""
+        curie = self.converter.format_curie("GO", "1234567")
         with self.app.test_client() as client:
-            res = client.get("/GO:1234567", follow_redirects=False)
+            res = client.get(f"/{curie}", follow_redirects=False)
             self.assertEqual(302, res.status_code, msg=res.text)
 
     def test_resolve_failure(self):
         """Test resolution for an invalid CURIE aborts with 404."""
+        curie = self.converter.format_curie("NOPREFIX", "NOIDENTIFIER")
         with self.app.test_client() as client:
-            res = client.get("/NOPREFIX:NOIDENTIFIER", follow_redirects=False)
+            res = client.get(f"/{curie}", follow_redirects=False)
             self.assertEqual(FAILURE_CODE, res.status_code, msg=res.text)
+
+
+class TestFlaskBlueprintSlashed(TestFlaskBlueprint):
+    """Test the flask blueprint with an alternate delimiter."""
+
+    delimiter = "/"
+
+    def test_delimiter(self):
+        """Test the delimiter."""
+        self.assertEqual("/", self.converter.delimiter)


### PR DESCRIPTION
This was necessary to get the ARK resolver working since the delimiter is a slash for https://cthoyt.com/2023/04/11/n2t-ark-resolver.html