### PR TITLE
Add reference datatypes and switch to pydantic

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ keywords =
 [options]
 install_requires =
     pytrie
+    pydantic
     requests
 
 # Random options

--- a/src/curies/__init__.py
+++ b/src/curies/__init__.py
@@ -8,6 +8,8 @@ from .api import (
     DuplicateURIPrefixes,
     DuplicateValueError,
     Record,
+    Reference,
+    ReferenceTuple,
     chain,
 )
 from .sources import (
@@ -23,6 +25,8 @@ from .web import get_fastapi_app, get_fastapi_router, get_flask_app, get_flask_b
 __all__ = [
     "Converter",
     "Record",
+    "ReferenceTuple",
+    "Reference",
     "DuplicateValueError",
     "DuplicateURIPrefixes",
     "DuplicatePrefixes",

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -136,7 +136,7 @@ class Record(BaseModel):  # type:ignore
         return v
 
     @validator("uri_prefix_synonyms")  # type:ignore
-    def uri_prefix_not_in_synonyms(cls, v: str, values: Mapping[str, Any]) -> sr:  # noqa:N805
+    def uri_prefix_not_in_synonyms(cls, v: str, values: Mapping[str, Any]) -> str:  # noqa:N805
         """Check that the canonical URI prefix does not apper in the URI prefix synonym list."""
         uri_prefix = values["uri_prefix"]
         if uri_prefix in v:

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -51,7 +51,13 @@ LocationOr = Union[str, Path, X]
 
 
 class ReferenceTuple(NamedTuple):
-    """A reference to an entity in a given identifier space."""
+    """A reference to an entity in a given identifier space.
+
+    This derives from the "named tuple" which means that it acts
+    like a tuple in most senses - it can be hashed and unpacked
+    like most other tuples. Underneath, it has a C implementation
+    and is very efficient.
+    """
 
     prefix: str
     identifier: str
@@ -68,9 +74,31 @@ class ReferenceTuple(NamedTuple):
         """
         return f"{self.prefix}:{self.identifier}"
 
+    @classmethod
+    def from_curie(cls, curie: str, sep: str = ":") -> "ReferenceTuple":
+        """Parse a CURIE string and populate a reference tuple.
+
+        :param curie: A string representation of a compact URI (CURIE)
+        :param sep: The separator
+        :return: A reference tuple
+
+        >>> ReferenceTuple.from_curie("chebi:1234")
+        ReferenceTuple(prefix='chebi', identifier='1234')
+        """
+        prefix, identifier = curie.split(sep, 1)
+        return cls(prefix, identifier)
+
 
 class Reference(BaseModel):  # type:ignore
-    """A reference to an entity in a given identifier space."""
+    """A reference to an entity in a given identifier space.
+
+    This class uses Pydantic to make it easier to build other
+    more complex data types with Pydantic that also uses a first-
+    class notion of parsed reference (instead of merely stringified
+    CURIEs). Instances of this class can also be hashed because of the
+    "frozen" configuration from Pydantic (see
+    https://docs.pydantic.dev/latest/usage/model_config/ for more details).
+    """
 
     prefix: str = Field(
         ...,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,6 +48,7 @@ class TestConverter(unittest.TestCase):
         """Test the reference tuple data type."""
         t = ReferenceTuple("chebi", "1234")
         self.assertEqual("chebi:1234", t.curie)
+        self.assertEqual(t, ReferenceTuple.from_curie("chebi:1234"))
 
     def test_reference_pydantic(self):
         """Test the reference Pydantic model."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,15 @@ import pandas as pd
 import rdflib
 from bioregistry.export.prefix_maps import EXTENDED_PREFIX_MAP_PATH
 
-from curies.api import Converter, DuplicatePrefixes, DuplicateURIPrefixes, Record, chain
+from curies.api import (
+    Converter,
+    DuplicatePrefixes,
+    DuplicateURIPrefixes,
+    Record,
+    Reference,
+    ReferenceTuple,
+    chain,
+)
 from curies.sources import (
     BIOREGISTRY_CONTEXTS,
     get_bioregistry_converter,
@@ -35,6 +43,17 @@ class TestConverter(unittest.TestCase):
             "OBO": "http://purl.obolibrary.org/obo/",
         }
         self.converter = Converter.from_prefix_map(self.simple_obo_prefix_map)
+
+    def test_reference_tuple(self):
+        """Test the reference tuple data type."""
+        t = ReferenceTuple("chebi", "1234")
+        self.assertEqual("chebi:1234", t.curie)
+
+    def test_reference_pydantic(self):
+        """Test the reference Pydantic model."""
+        t = Reference(prefix="chebi", identifier="1234")
+        self.assertEqual("chebi:1234", t.curie)
+        self.assertEqual(t, Reference.from_curie("chebi:1234"))
 
     def test_invalid_record(self):
         """Test throwing an error for invalid records."""


### PR DESCRIPTION
In many projects, I have had to re-define data types for parsed CURIEs. since this is the most fundamental package for handling these objects, it makes sense to put two flavors here - one as a named tuple and one as a pydantic class. Basically, they both have the same interface but are useful in different places.

## Pydantic

```python
from curies import Reference

>>> Reference(prefix="chebi", identifier="1234").curie
"chebi:1234"

>>> Reference.from_curie("chebi:1234")
Reference(prefix='chebi', identifier='1234')
```

## Tuples

```Python
from curies import ReferenceTuple

>>> ReferenceTuple("chebi", "1234")
ReferenceTuple(prefix='chebi', identifier='1234')

>>> ReferenceTuple("chebi", "1234").curie
"chebi:1234"

>>> ReferenceTuple.from_curie("chebi:1234")
ReferenceTuple(prefix='chebi', identifier='1234')
