### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.11" ]
+        python-version: [ "3.8", "3.11" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.11" ]
+        python-version: [ "3.8", "3.11" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.7", "3.11" ]
+        python-version: [ "3.8", "3.11" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.black]
 line-length = 100
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ classifiers =
     Framework :: tox
     Framework :: Sphinx
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -60,7 +59,7 @@ install_requires =
 # Random options
 zip_safe = false
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 
 # Where is my code
 packages = find:

--- a/src/curies/web.py
+++ b/src/curies/web.py
@@ -206,7 +206,7 @@ def get_fastapi_router(converter: Converter, **kwargs: Any) -> "fastapi.APIRoute
         prefix: str = Path(  # noqa:B008
             title="Prefix",
             description="The Bioregistry prefix corresponding to an identifier resource.",
-            example="doid",
+            examples=["doid"],
         ),
         identifier: str = Path(  # noqa:B008
             title="Local Unique Identifier",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -42,13 +42,13 @@ class TestFastAPI(ConverterMixin):
     def test_resolve_success(self):
         """Test resolution for a valid CURIE redirects properly."""
         curie = self.converter.format_curie("GO", "1234567")
-        res = self.client.get(f"/{curie}", allow_redirects=False)
+        res = self.client.get(f"/{curie}", follow_redirects=False)
         self.assertEqual(302, res.status_code, msg=res.text)
 
     def test_resolve_failure(self):
         """Test resolution for an invalid CURIE aborts with 404."""
         curie = self.converter.format_curie("NOPREFIX", "NOIDENTIFIER")
-        res = self.client.get(f"/{curie}", allow_redirects=False)
+        res = self.client.get(f"/{curie}", follow_redirects=False)
         self.assertEqual(FAILURE_CODE, res.status_code, msg=res.text)
 
 


### PR DESCRIPTION
Python 3.7 is now past end-of-life. Therefore it doesn't make sense to test or support it.