### PR TITLE
Make explicit cross-version support for Pydantic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ "3.8", "3.11" ]
+        pydantic: [ "1", "2" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -68,7 +69,7 @@ jobs:
         run: pip install tox
       - name: Test with pytest and generate coverage file
         run:
-          tox run -e py
+          tox run -e py-pydantic${{ matrix.pydantic }}
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v1
         if: success()

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ The most recent release can be installed from
 $ pip install curies
 ```
 
+This package currently supports both Pydantic v1 and v2. See the
+[Pydantic migration guide](https://docs.pydantic.dev/2.0/migration/)
+for updating your code.
+
 ## 👐 Contributing
 
 Contributions, whether filing an issue, making a pull request, or forking, are appreciated. See

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,6 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     # 'texext',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,10 @@ The most recent code and data can be installed directly from GitHub with:
 
     $ pip install git+https://github.com/cthoyt/curies.git
 
+This package currently supports both Pydantic v1 and v2. See the
+`Pydantic migration guide <https://docs.pydantic.dev/2.0/migration>`_
+for updating your code.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ keywords =
 [options]
 install_requires =
     pytrie
-    pydantic<2.0
+    pydantic
     requests
 
 # Random options

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,9 +87,8 @@ fastapi =
 rdflib =
     rdflib
 docs =
-    sphinx<7.0
+    sphinx
     sphinx-rtd-theme
-    sphinx-autodoc-typehints
     sphinx_automodapi
 
 ######################

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,8 @@ envlist =
     docstr-coverage
     docs-test
     # the actual tests
-    py
+    py-pydantic1
+    py-pydantic2
     doctests
     # always keep coverage-report last
     # coverage-report
@@ -35,6 +36,9 @@ commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml
+deps =
+    pydantic1: pydantic<2.0
+    pydantic2: pydantic>=2.0
 extras =
     tests
     pandas


### PR DESCRIPTION
curies is a distal transitive dependency of many packages, it needs to be neutral w.r.t pydantic version. It looks like it already is, and the pinning to <2 is unneccessary

For more context see https://github.com/biopragmatics/bioregistry/issues/920