### PR TITLE
Remove Bioregistry from testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,8 +75,6 @@ tests =
     coverage
 pandas =
     pandas
-bioregistry =
-    bioregistry>=0.5.136
 flask =
     flask
     defusedxml

--- a/src/curies/sources.py
+++ b/src/curies/sources.py
@@ -60,6 +60,7 @@ def get_bioregistry_converter(web: bool = False, **kwargs: Any) -> Converter:
         except ImportError:  # pragma: no cover
             pass
         else:
-            return Converter.from_extended_prefix_map(bioregistry.manager.get_curies_records())
+            epm = bioregistry.manager.get_curies_records()  # pragma: no cover
+            return Converter.from_extended_prefix_map(epm)  # pragma: no cover
     url = f"{BIOREGISTRY_CONTEXTS}/bioregistry.epm.json"
     return Converter.from_extended_prefix_map(url, **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,6 @@ from tempfile import TemporaryDirectory
 
 import pandas as pd
 import rdflib
-from bioregistry.export.prefix_maps import EXTENDED_PREFIX_MAP_PATH
 
 from curies.api import (
     CompressionError,
@@ -208,16 +207,6 @@ class TestConverter(unittest.TestCase):
         chebi_uri = converter.prefix_map["chebi"]
         self.assertIn(chebi_uri, converter.reverse_prefix_map)
         self.assertEqual("chebi", converter.reverse_prefix_map[chebi_uri])
-
-    @unittest.skipUnless(
-        EXTENDED_PREFIX_MAP_PATH.is_file(),
-        reason="missing local, editable installation of the Bioregistry",
-    )
-    def test_bioregistry_editable(self):
-        """Test loading the bioregistry extended prefix map locally."""
-        records = json.loads(EXTENDED_PREFIX_MAP_PATH.read_text())
-        converter = Converter.from_extended_prefix_map(records)
-        self.assert_bioregistry_converter(converter)
 
     def test_load_path(self):
         """Test loading from paths."""

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ commands =
 extras =
     tests
     pandas
-    bioregistry
     flask
     fastapi
     rdflib


### PR DESCRIPTION
This is to prepare for making pydantic 1/2 cross-compatible, since Bioregistry is currently pinned to pydantic<2.0