### PR TITLE
Add subsetting functionality

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1128,6 +1128,21 @@ class Converter:
         :param df: A pandas DataFrame
         :param column: The column in the dataframe containing CURIEs to standardize.
         :param target_column: The column to put the results in. Defaults to input column.
+
+        The Disease Ontology curates mappings to other semantic spaces and distributes them in the
+        tabular SSSOM format. However, they use a wide variety of non-standard prefixes for referring
+        to external vocabularies like SNOMED-CT. The Bioregistry contains these synonyms to support
+        reconciliation. The following example shows how the SSSOM mappings dataframe can be loaded
+        and this function applied to the mapping ``object_id`` column (in place).
+
+        >>> import curies
+        >>> import pandas as pd
+        >>> import itertools as itt
+        >>> commit = "faca4fc335f9a61902b9c47a1facd52a0d3d2f8b"
+        >>> url = f"https://github.com/mapping-commons/disease-mappings/blob/{commit}/mappings/doid.sssom.tsv"
+        >>> df = pd.read_csv(url, sep="\t", comment='#')
+        >>> converter = curies.get_bioregistry_converter()
+        >>> converter.pd_standardize_curie(df, column="object_id")
         """
         df[column if target_column is None else target_column] = df[column].map(
             self.standardize_curie
@@ -1234,7 +1249,7 @@ class Converter:
         >>> import itertools as itt
         >>> commit = "faca4fc335f9a61902b9c47a1facd52a0d3d2f8b"
         >>> url = f"https://github.com/mapping-commons/disease-mappings/blob/{commit}/mappings/doid.sssom.tsv"
-        >>> df = pd.read_csv(url, sep="\t")
+        >>> df = pd.read_csv(url, sep="\t", comment='#')
         >>> prefixes = {
         ...     curies.Reference.from_curie(curie).prefix
         ...     for column in ["subject_id", "predicate_id", "object_id"]

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1205,7 +1205,7 @@ class Converter:
                 return record
         return None
 
-    def get_subset(self, prefixes: Iterable[str]) -> "Converter":
+    def get_subconverter(self, prefixes: Iterable[str]) -> "Converter":
         """Get a converter with a subset of prefixes."""
         prefixes = set(prefixes)
         records = [

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1139,7 +1139,7 @@ class Converter:
         >>> import pandas as pd
         >>> import itertools as itt
         >>> commit = "faca4fc335f9a61902b9c47a1facd52a0d3d2f8b"
-        >>> url = f"https://github.com/mapping-commons/disease-mappings/blob/{commit}/mappings/doid.sssom.tsv"
+        >>> url = f"https://raw.githubusercontent.com/mapping-commons/disease-mappings/{commit}/mappings/doid.sssom.tsv"
         >>> df = pd.read_csv(url, sep="\t", comment='#')
         >>> converter = curies.get_bioregistry_converter()
         >>> converter.pd_standardize_curie(df, column="object_id")
@@ -1248,7 +1248,7 @@ class Converter:
         >>> import pandas as pd
         >>> import itertools as itt
         >>> commit = "faca4fc335f9a61902b9c47a1facd52a0d3d2f8b"
-        >>> url = f"https://github.com/mapping-commons/disease-mappings/blob/{commit}/mappings/doid.sssom.tsv"
+        >>> url = f"https://raw.githubusercontent.com/mapping-commons/disease-mappings/{commit}/mappings/doid.sssom.tsv"
         >>> df = pd.read_csv(url, sep="\t", comment='#')
         >>> prefixes = {
         ...     curies.Reference.from_curie(curie).prefix

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1205,6 +1205,16 @@ class Converter:
                 return record
         return None
 
+    def get_subset(self, prefixes: Iterable[str]) -> "Converter":
+        """Get a converter with a subset of prefixes."""
+        prefixes = set(prefixes)
+        records = [
+            record
+            for record in self.records
+            if any(prefix in prefixes for prefix in record._all_prefixes)
+        ]
+        return Converter(records)
+
 
 def _eq(a: str, b: str, case_sensitive: bool) -> bool:
     if case_sensitive:

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1123,7 +1123,7 @@ class Converter:
         column: Union[str, int],
         target_column: Union[None, str, int] = None,
     ) -> None:
-        """Standardize all CURIEs in the given column.
+        r"""Standardize all CURIEs in the given column.
 
         :param df: A pandas DataFrame
         :param column: The column in the dataframe containing CURIEs to standardize.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -251,7 +251,7 @@ class TestConverter(unittest.TestCase):
 
     def test_subset(self):
         """Test subsetting a converter."""
-        new_converter = self.converter.get_subset(["CHEBI"])
+        new_converter = self.converter.get_subconverter(["CHEBI"])
         self.assertEqual(1, len(new_converter.records))
         self.assertEqual({"CHEBI"}, new_converter.get_prefixes())
         self.assertEqual({"CHEBI"}, set(new_converter.bimap))
@@ -262,7 +262,7 @@ class TestConverter(unittest.TestCase):
 
     def test_empty_subset(self):
         """Test subsetting a converter and getting an empty one back."""
-        new_converter_2 = self.converter.get_subset(["NOPE"])
+        new_converter_2 = self.converter.get_subconverter(["NOPE"])
         self.assertEqual(0, len(new_converter_2.records))
 
     def test_convert(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -249,6 +249,22 @@ class TestConverter(unittest.TestCase):
             strict=False,
         )
 
+    def test_subset(self):
+        """Test subsetting a converter."""
+        new_converter = self.converter.get_subset(["CHEBI"])
+        self.assertEqual(1, len(new_converter.records))
+        self.assertEqual({"CHEBI"}, new_converter.get_prefixes())
+        self.assertEqual({"CHEBI"}, set(new_converter.bimap))
+        self.assertEqual({"CHEBI"}, set(new_converter.prefix_map))
+        self.assertEqual(
+            {"http://purl.obolibrary.org/obo/CHEBI_"}, set(new_converter.reverse_prefix_map)
+        )
+
+    def test_empty_subset(self):
+        """Test subsetting a converter and getting an empty one back."""
+        new_converter_2 = self.converter.get_subset(["NOPE"])
+        self.assertEqual(0, len(new_converter_2.records))
+
     def test_convert(self):
         """Test compression."""
         self.assertEqual({"CHEBI", "MONDO", "GO", "OBO"}, self.converter.get_prefixes())


### PR DESCRIPTION
This functionality is useful for downstream applications like the following:

1. You load a comprehensive extended prefix map, e.g., from the Bioregistry using `curies.get_bioregistry_converter()`.
2. You load some data that conforms to this prefix map by convention. This is often the case for semantic mappings stored in the SSSOM format
3. You extract the list of prefixes _actually_ used within your data
4. You subset the detailed extended prefix map to only include prefixes relevant for your data
5. You make some kind of output of the subsetted extended prefix map to go with your data. Effectively, this is a way of reconciling data. This is especially effective when using the Bioregistry or other comprehensive extended prefix maps.

Here's a concrete example of doing this (which also includes a bit of data science)
to do this on the SSSOM mappings from the Disease Ontology project.

```python
>>> import curies
>>> import pandas as pd
>>> import itertools as itt
>>> commit = "faca4fc335f9a61902b9c47a1facd52a0d3d2f8b"
>>> url = f"https://github.com/mapping-commons/disease-mappings/blob/{commit}/mappings/doid.sssom.tsv"
>>> df = pd.read_csv(url, sep="\t", comment="#")
>>> prefixes = {
...     curies.Reference.from_curie(curie).prefix
...     for column in ["subject_id", "predicate_id", "object_id"]
...     for curie in df[column]
... }
>>> converter = curies.get_bioregistry_converter()
>>> slim_converter = converter.get_subconverter(prefixes)
```


This PR also sneaks in a related documentation update to pandas dataframe processing