### PR TITLE
Enable transitive reconciliaton

### DIFF
--- a/docs/source/reconciliation.rst
+++ b/docs/source/reconciliation.rst
@@ -92,6 +92,26 @@ If neither the old prefix nor new prefix appear in the extended prefix maps, one
 1. Do nothing (lenient)
 2. Raise an exception (strict)
 
+Transitive CURIE Prefix Remapping
+---------------------------------
+There's a special case of CURIE prefix remapping where one prefix is supposed to overwrite another. For example,
+in the Bioregistry, the `Gene Expression Omnibus <https://www.ncbi.nlm.nih.gov/geo/>`_ is given the prefix ``geo``
+and the `Geographical Entity Ontology <https://obofoundry.org/ontology/geo>`_ is given the
+prefix ``geogeo``. OBO Foundry users will want to rename the Gene Expression Omnibus record to something else
+like ``ncbi.geo`` and rename ``geogeo`` to ``geo``. Taken by themselves, these two operations would not accomplish
+the desired results:
+
+1. Remapping with ``{"geo": "ncbi.geo"}`` would retain ``geo`` as a CURIE prefix synonym
+2. Remapping with ``{"geogeo": "geo"}`` would not change the mapping as ``geo`` is already part of a different record.
+
+The :func:`curies.remap_curie_prefixes` implements special logic to identify scenarios where two (or more) remappings
+are dependent (we're calling these *transitive remappings*) and apply them in the expected way.
+
+.. note::
+
+    This is not the same as an "overwrite" which would delete the original ``geo`` operation. This package
+    expects that you give a new name such that no records are lost.
+
 URI Prefix Remapping
 ----------------------
 URI prefix remapping is configured by a mapping from existing URI prefixes to new URI prefixes.
@@ -174,23 +194,3 @@ any record in the extended prefix map, do one of the following:
 
 1. Do nothing (lenient)
 2. Raise an exception (strict)
-
-Transitive Remappings
----------------------
-There's a special case of CURIE prefix remapping where one prefix is supposed to overwrite another. For example,
-in the Bioregistry, the `Gene Expression Omnibus <https://www.ncbi.nlm.nih.gov/geo/>`_ is given the prefix ``geo``
-and the `Geographical Entity Ontology <https://obofoundry.org/ontology/geo>`_ is given the
-prefix ``geogeo``. OBO Foundry users will want to rename the Gene Expression Omnibus record to something else
-like ``ncbi.geo`` and rename ``geogeo`` to ``geo``. Taken by themselves, these two operations would not accomplish
-the desired results:
-
-1. Remapping with ``{"geo": "ncbi.geo"}`` would retain ``geo`` as a CURIE prefix synonym
-2. Remapping with ``{"geogeo": "geo"}`` would not change the mapping as ``geo`` is already part of a different record.
-
-The :func:`curies.remap_curie_prefixes` implements special logic to identify scenarios where two (or more) remappings
-are dependent (we're calling these *transitive remappings*) and apply them in the expected way.
-
-.. note::
-
-    This is not the same as an "overwrite" which would delete the original ``geo`` operation. This package
-    expects that you give a new name such that no records are lost.

--- a/docs/source/reconciliation.rst
+++ b/docs/source/reconciliation.rst
@@ -105,12 +105,40 @@ the desired results:
 2. Remapping with ``{"geogeo": "geo"}`` would not change the mapping as ``geo`` is already part of a different record.
 
 The :func:`curies.remap_curie_prefixes` implements special logic to identify scenarios where two (or more) remappings
-are dependent (we're calling these *transitive remappings*) and apply them in the expected way.
+are dependent (we're calling these *transitive remappings*) and apply them in the expected way. Therefore, we
+see the following
+
+.. code-block:: python
+
+    from curies import Converter, Record, remap_curie_prefixes
+
+    converter = Converter([
+        Record(prefix="geo", uri_prefix="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc="),
+        Record(prefix="geogeo", uri_prefix="http://purl.obolibrary.org/obo/GEO_"),
+    ])
+    remapping = {"geo": "ncbi.geo", "geogeo": "geo"}
+    converter = remap_curie_prefixes(converter, curie_remapping)
+
+    >>> converter.records
+    [
+        Record(
+            prefix="geo",
+            prefix_synonyms=["geogeo"],
+            uri_prefix="http://purl.obolibrary.org/obo/GEO_",
+        ),
+        Record(
+            prefix="ncbi.geo",
+            uri_prefix="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=",
+        ),
+    ]
+
+``geogeo`` is maintained as a CURIE prefix synonym for the Geographical Entity Ontology's record. Synonyms
+of Gene Expression Omnibus would also be retained.
 
 .. note::
 
     This is not the same as an "overwrite" which would delete the original ``geo`` operation. This package
-    expects that you give a new name such that no records are lost.
+    expects that you give a new CURIE prefix to all "overwritten" records such that no records are lost.
 
 .. warning::
 

--- a/docs/source/reconciliation.rst
+++ b/docs/source/reconciliation.rst
@@ -112,6 +112,23 @@ are dependent (we're calling these *transitive remappings*) and apply them in th
     This is not the same as an "overwrite" which would delete the original ``geo`` operation. This package
     expects that you give a new name such that no records are lost.
 
+.. warning::
+
+    Primary prefixes must be used when doing transitive remappings. Handling synonyms proved to be too complex.
+    Therefore, if you use a CURIE prefix remapping like in the following, you will get an exception.
+
+    .. code-block::
+
+        converter = Converter([
+            Record(
+                prefix="geo",
+                prefix_synonyms=["ggg"],
+                uri_prefix="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=",
+            ),
+            Record(prefix="geogeo", uri_prefix="http://purl.obolibrary.org/obo/GEO_"),
+        ])
+        curie_remapping = {"ggg": "ncbi.geo", "geogeo": "geo"}
+
 URI Prefix Remapping
 ----------------------
 URI prefix remapping is configured by a mapping from existing URI prefixes to new URI prefixes.

--- a/docs/source/reconciliation.rst
+++ b/docs/source/reconciliation.rst
@@ -175,15 +175,22 @@ any record in the extended prefix map, do one of the following:
 1. Do nothing (lenient)
 2. Raise an exception (strict)
 
-Transitive Mappings
--------------------
-There's an important drawback to the current implementation of CURIE remapping - it is not able to consistently
-and correctly handle the case when the order of remapping records matters. For example, in the Bioregistry,
-the `Gene Expression Omnibus <https://www.ncbi.nlm.nih.gov/geo/>`_ is given the prefix ``geo`` and the
-`Geographical Entity Ontology <https://obofoundry.org/ontology/geo>`_ is given the
+Transitive Remappings
+---------------------
+There's a special case of CURIE prefix remapping where one prefix is supposed to overwrite another. For example,
+in the Bioregistry, the `Gene Expression Omnibus <https://www.ncbi.nlm.nih.gov/geo/>`_ is given the prefix ``geo``
+and the `Geographical Entity Ontology <https://obofoundry.org/ontology/geo>`_ is given the
 prefix ``geogeo``. OBO Foundry users will want to rename the Gene Expression Omnibus record to something else
-like ``ncbi.geo`` and rename ``geogeo`` to ``geo``. This is possible in theory, but requires an implementation
-that will require additional introspection over the values appearing in both the keys and values of a remapping
-as well as changing the way that the records are modified.
+like ``ncbi.geo`` and rename ``geogeo`` to ``geo``. Taken by themselves, these two operations would not accomplish
+the desired results:
 
-.. seealso:: Discussion about this issue on https://github.com/cthoyt/curies/issues/75
+1. Remapping with ``{"geo": "ncbi.geo"}`` would retain ``geo`` as a CURIE prefix synonym
+2. Remapping with ``{"geogeo": "geo"}`` would not change the mapping as ``geo`` is already part of a different record.
+
+The :func:`curies.remap_curie_prefixes` implements special logic to identify scenarios where two (or more) remappings
+are dependent (we're calling these *transitive remappings*) and apply them in the expected way.
+
+.. note::
+
+    This is not the same as an "overwrite" which would delete the original ``geo`` operation. This package
+    expects that you give a new name such that no records are lost.

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -432,7 +432,7 @@ class Converter:
                 raise DuplicatePrefixes(duplicate_prefixes)
 
         self.delimiter = delimiter
-        self.records = records
+        self.records = sorted(records, key=lambda r: r.prefix)
         self.prefix_map = _get_prefix_map(records)
         self.synonym_to_prefix = _get_prefix_synmap(records)
         self.reverse_prefix_map = _get_reverse_prefix_map(records)

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1273,7 +1273,7 @@ class Converter:
         """Get the record for the prefix."""
         # TODO better data structure for this
         for record in self.records:
-            if record.prefix == prefix:
+            if record.prefix == prefix or prefix in record.prefix_synonyms:
                 return record
         return None
 

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -23,6 +23,22 @@ class TestUtils(unittest.TestCase):
 class TestCURIERemapping(unittest.TestCase):
     """A test case for CURIE prefix remapping."""
 
+    def test_duplicates(self):
+        """Test detecting bad mapping with duplicates."""
+        curie_remapping = {"b": "c", "d": "c"}
+        with self.assertRaises(ValueError):
+            remap_curie_prefixes(..., curie_remapping)
+
+    def test_cycles(self):
+        """Test detecting bad mapping with duplicates."""
+        curie_remapping = {"b": "c", "c": "b"}
+        with self.assertRaises(ValueError):
+            remap_curie_prefixes(..., curie_remapping)
+
+        curie_remapping = {"a": "b", "b": "c", "c": "a"}
+        with self.assertRaises(ValueError):
+            remap_curie_prefixes(..., curie_remapping)
+
     def test_missing(self):
         """Test simple upgrade."""
         records = [

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -125,6 +125,35 @@ class TestCURIERemapping(unittest.TestCase):
             converter.records,
         )
 
+    def test_simultaneous_synonym(self):
+        """Test simultaneous remapping."""
+        records = [
+            Record(
+                prefix="geo",
+                prefix_synonyms=["ggg"],
+                uri_prefix="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=",
+            ),
+            Record(prefix="geogeo", uri_prefix="http://purl.obolibrary.org/obo/GEO_"),
+        ]
+        converter = Converter(records)
+        curie_remapping = {"ggg": "ncbi.geo", "geogeo": "geo"}
+        converter = remap_curie_prefixes(converter, curie_remapping)
+        self.assertEqual(
+            [
+                Record(
+                    prefix="geo",
+                    prefix_synonyms=["geogeo"],
+                    uri_prefix="http://purl.obolibrary.org/obo/GEO_",
+                ),
+                Record(
+                    prefix="ncbi.geo",
+                    prefix_synonyms=["ggg"],
+                    uri_prefix="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=",
+                ),
+            ],
+            converter.records,
+        )
+
 
 class TestURIRemapping(unittest.TestCase):
     """A test case for URI prefix remapping."""

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -30,7 +30,7 @@ class TestCURIERemapping(unittest.TestCase):
             remap_curie_prefixes(..., curie_remapping)
 
     def test_cycles(self):
-        """Test detecting bad mapping with duplicates."""
+        """Test detecting bad mapping with cycles."""
         curie_remapping = {"b": "c", "c": "b"}
         with self.assertRaises(ValueError):
             remap_curie_prefixes(..., curie_remapping)

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -4,11 +4,11 @@ import unittest
 
 from curies import Converter, Record, remap_curie_prefixes, remap_uri_prefixes, rewire
 from curies.reconciliation import (
-    _order_mappings,
-    DuplicateValues,
-    DuplicateKeys,
-    InconsistentMapping,
     CycleDetected,
+    DuplicateKeys,
+    DuplicateValues,
+    InconsistentMapping,
+    _order_curie_remapping,
 )
 
 #: The beginning of URIs used throughout examples
@@ -28,11 +28,15 @@ class TestUtils(unittest.TestCase):
             ]
         )
         self.assertEqual(
-            [("a", "a1"), ("b", "b1")], _order_mappings(converter, {"a": "a1", "b": "b1"})
+            [("a", "a1"), ("b", "b1")], _order_curie_remapping(converter, {"a": "a1", "b": "b1"})
         )
         # we want to be as low down the chain first. Test both constructions of the dictionary
-        self.assertEqual([("c", "a"), ("b", "c")], _order_mappings(converter, {"c": "a", "b": "c"}))
-        self.assertEqual([("c", "a"), ("b", "c")], _order_mappings(converter, {"b": "c", "c": "a"}))
+        self.assertEqual(
+            [("c", "a"), ("b", "c")], _order_curie_remapping(converter, {"c": "a", "b": "c"})
+        )
+        self.assertEqual(
+            [("c", "a"), ("b", "c")], _order_curie_remapping(converter, {"b": "c", "c": "a"})
+        )
 
     def test_duplicate_values(self):
         """Test detecting bad mapping with duplicate."""
@@ -45,7 +49,7 @@ class TestUtils(unittest.TestCase):
         )
         curie_remapping = {"b": "c", "a": "c"}
         with self.assertRaises(DuplicateValues):
-            _order_mappings(converter, curie_remapping)
+            _order_curie_remapping(converter, curie_remapping)
 
     def test_duplicate_keys(self):
         """Test detecting a bad mapping that contains multiple references to the same record in the keys."""
@@ -58,10 +62,10 @@ class TestUtils(unittest.TestCase):
         )
         curie_remapping = {"a": "c", "a1": "b"}
         with self.assertRaises(DuplicateKeys):
-            _order_mappings(converter, curie_remapping)
+            _order_curie_remapping(converter, curie_remapping)
 
     def test_duplicate_correspondence(self):
-        """Test detecting a bad mapping that contains inconsistent references to the same record in the keys and values."""
+        """Test detecting a bad mapping containing inconsistent references to the same record in the keys and values."""
         converter = Converter(
             [
                 Record(prefix="a", prefix_synonyms=["a1"], uri_prefix=f"{P}/a/"),
@@ -71,7 +75,7 @@ class TestUtils(unittest.TestCase):
         )
         curie_remapping = {"a": "c", "b": "a1"}
         with self.assertRaises(InconsistentMapping):
-            _order_mappings(converter, curie_remapping)
+            _order_curie_remapping(converter, curie_remapping)
 
     def test_cycles(self):
         """Test detecting bad mapping with cycles."""
@@ -88,7 +92,7 @@ class TestUtils(unittest.TestCase):
 
         curie_remapping = {"a": "b", "b": "c", "c": "a"}
         with self.assertRaises(CycleDetected):
-            _order_mappings(converter, curie_remapping)
+            _order_curie_remapping(converter, curie_remapping)
 
 
 class TestCURIERemapping(unittest.TestCase):

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -3,7 +3,13 @@
 import unittest
 
 from curies import Converter, Record, remap_curie_prefixes, remap_uri_prefixes, rewire
-from curies.reconciliation import _order_mappings
+from curies.reconciliation import (
+    _order_mappings,
+    DuplicateValues,
+    DuplicateKeys,
+    InconsistentMapping,
+    CycleDetected,
+)
 
 #: The beginning of URIs used throughout examples
 P = "https://example.org"
@@ -14,30 +20,79 @@ class TestUtils(unittest.TestCase):
 
     def test_ordering(self):
         """Test ordering."""
-        self.assertEqual([("a", "a1"), ("b", "b1")], _order_mappings({"a": "a1", "b": "b1"}))
+        converter = Converter(
+            [
+                Record(prefix="a", uri_prefix=f"{P}/a/"),
+                Record(prefix="b", uri_prefix=f"{P}/b/"),
+                Record(prefix="c", uri_prefix=f"{P}/c/"),
+            ]
+        )
+        self.assertEqual(
+            [("a", "a1"), ("b", "b1")], _order_mappings(converter, {"a": "a1", "b": "b1"})
+        )
         # we want to be as low down the chain first. Test both constructions of the dictionary
-        self.assertEqual([("c", "a"), ("b", "c")], _order_mappings({"c": "a", "b": "c"}))
-        self.assertEqual([("c", "a"), ("b", "c")], _order_mappings({"b": "c", "c": "a"}))
+        self.assertEqual([("c", "a"), ("b", "c")], _order_mappings(converter, {"c": "a", "b": "c"}))
+        self.assertEqual([("c", "a"), ("b", "c")], _order_mappings(converter, {"b": "c", "c": "a"}))
+
+    def test_duplicate_values(self):
+        """Test detecting bad mapping with duplicate."""
+        converter = Converter(
+            [
+                Record(prefix="a", uri_prefix=f"{P}/a/"),
+                Record(prefix="b", uri_prefix=f"{P}/b/"),
+                Record(prefix="c", uri_prefix=f"{P}/c/"),
+            ]
+        )
+        curie_remapping = {"b": "c", "a": "c"}
+        with self.assertRaises(DuplicateValues):
+            _order_mappings(converter, curie_remapping)
+
+    def test_duplicate_keys(self):
+        """Test detecting a bad mapping that contains multiple references to the same record in the keys."""
+        converter = Converter(
+            [
+                Record(prefix="a", prefix_synonyms=["a1"], uri_prefix=f"{P}/a/"),
+                Record(prefix="b", uri_prefix=f"{P}/b/"),
+                Record(prefix="c", uri_prefix=f"{P}/c/"),
+            ]
+        )
+        curie_remapping = {"a": "c", "a1": "b"}
+        with self.assertRaises(DuplicateKeys):
+            _order_mappings(converter, curie_remapping)
+
+    def test_duplicate_correspondence(self):
+        """Test detecting a bad mapping that contains inconsistent references to the same record in the keys and values."""
+        converter = Converter(
+            [
+                Record(prefix="a", prefix_synonyms=["a1"], uri_prefix=f"{P}/a/"),
+                Record(prefix="b", uri_prefix=f"{P}/b/"),
+                Record(prefix="c", uri_prefix=f"{P}/c/"),
+            ]
+        )
+        curie_remapping = {"a": "c", "b": "a1"}
+        with self.assertRaises(InconsistentMapping):
+            _order_mappings(converter, curie_remapping)
+
+    def test_cycles(self):
+        """Test detecting bad mapping with cycles."""
+        converter = Converter(
+            [
+                Record(prefix="a", uri_prefix=f"{P}/a/"),
+                Record(prefix="b", uri_prefix=f"{P}/b/"),
+                Record(prefix="c", uri_prefix=f"{P}/c/"),
+            ]
+        )
+        curie_remapping = {"b": "c", "c": "b"}
+        with self.assertRaises(CycleDetected):
+            remap_curie_prefixes(converter, curie_remapping)
+
+        curie_remapping = {"a": "b", "b": "c", "c": "a"}
+        with self.assertRaises(CycleDetected):
+            _order_mappings(converter, curie_remapping)
 
 
 class TestCURIERemapping(unittest.TestCase):
     """A test case for CURIE prefix remapping."""
-
-    def test_duplicates(self):
-        """Test detecting bad mapping with duplicates."""
-        curie_remapping = {"b": "c", "d": "c"}
-        with self.assertRaises(ValueError):
-            remap_curie_prefixes(..., curie_remapping)
-
-    def test_cycles(self):
-        """Test detecting bad mapping with cycles."""
-        curie_remapping = {"b": "c", "c": "b"}
-        with self.assertRaises(ValueError):
-            remap_curie_prefixes(..., curie_remapping)
-
-        curie_remapping = {"a": "b", "b": "c", "c": "a"}
-        with self.assertRaises(ValueError):
-            remap_curie_prefixes(..., curie_remapping)
 
     def test_missing(self):
         """Test simple upgrade."""
@@ -126,7 +181,7 @@ class TestCURIERemapping(unittest.TestCase):
         )
 
     def test_simultaneous_synonym(self):
-        """Test simultaneous remapping."""
+        """Test simultaneous remapping with synonyms raises an error."""
         records = [
             Record(
                 prefix="geo",
@@ -137,22 +192,8 @@ class TestCURIERemapping(unittest.TestCase):
         ]
         converter = Converter(records)
         curie_remapping = {"ggg": "ncbi.geo", "geogeo": "geo"}
-        converter = remap_curie_prefixes(converter, curie_remapping)
-        self.assertEqual(
-            [
-                Record(
-                    prefix="geo",
-                    prefix_synonyms=["geogeo"],
-                    uri_prefix="http://purl.obolibrary.org/obo/GEO_",
-                ),
-                Record(
-                    prefix="ncbi.geo",
-                    prefix_synonyms=["ggg"],
-                    uri_prefix="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=",
-                ),
-            ],
-            converter.records,
-        )
+        with self.assertRaises(InconsistentMapping):
+            remap_curie_prefixes(converter, curie_remapping)
 
 
 class TestURIRemapping(unittest.TestCase):


### PR DESCRIPTION
Closes #75

This PR enables transitive reconciliation of CURIE prefix remapping. This solves the problem when you have a CURIE prefix remapping like `{"geo": "ncbi.geo", "geogeo": "geo"}`. It's smart enough to know that you want to first fix the name of `geo` then remap `geogeo` onto it.

This does not allow you to simply do `{"geo": "ncbi.geo"}` as this would create a clash, so nothing would happen when using this remapping.

Example usage:

```python
from curies import Record, Converter, remap_curie_prefixes

records = [
    Record(prefix="geo", uri_prefix="https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc="),
    Record(prefix="geogeo", uri_prefix="http://purl.obolibrary.org/obo/GEO_"),
]
converter = Converter(records)
remapping = {"geo": "ncbi.geo", "geogeo": "geo"}

new_converter = remap_curie_prefixes(converter, remapping)
>>> new_converter.records
[
    Record(prefix='geo', uri_prefix='http://purl.obolibrary.org/obo/GEO_', prefix_synonyms=['geogeo'], uri_prefix_synonyms=[]), 
    Record(prefix='ncbi.geo', uri_prefix='https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=', prefix_synonyms=[], uri_prefix_synonyms=[])
]

