### PR TITLE
Add options for strict and passthrough to standardization

### DIFF
--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -326,15 +326,15 @@ class StandardizationError(ValueError):
 
 
 class PrefixStandardizationError(StandardizationError):
-    pass
+    """An error raise when a prefix can't be standardized."""
 
 
 class CURIEStandardizationError(StandardizationError):
-    pass
+    """An error raise when a CURIE can't be standardized."""
 
 
 class URIStandardizationError(StandardizationError):
-    pass
+    """An error raise when a URI can't be standardized."""
 
 
 def _get_duplicate_uri_prefixes(records: List[Record]) -> List[DuplicateSummary]:

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -911,8 +911,9 @@ class Converter:
 
         :param uri:
             A string representing a valid uniform resource identifier (URI)
-        :param strict: If true and the URI can't be compressed, returns an error
+        :param strict: If true and the URI can't be compressed, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the URI can't be compressed, return the input.
+            Defaults to false.
         :returns:
             A compact URI if this converter could find an appropriate URI prefix, otherwise none.
         :raises CompressionError:
@@ -994,8 +995,9 @@ class Converter:
 
         :param curie:
             A string representing a compact URI
-        :param strict: If true and the CURIE can't be expanded, returns an error
+        :param strict: If true and the CURIE can't be expanded, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the CURIE can't be expanded, return the input.
+            Defaults to false.
         :returns:
             A URI if this converter contains a URI prefix for the prefix in this CURIE
         :raises ExpansionError:
@@ -1147,8 +1149,9 @@ class Converter:
 
         :param prefix:
             The prefix of the CURIE
-        :param strict: If true and the prefix can't be standardized, returns an error
+        :param strict: If true and the prefix can't be standardized, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the prefix can't be standardized, return the input.
+            Defaults to false.
         :returns:
             The standardized version of this prefix wrt this converter.
             If the prefix is not registered in this converter, returns none.
@@ -1205,8 +1208,9 @@ class Converter:
 
         :param curie:
             A string representing a compact URI (CURIE)
-        :param strict: If true and the CURIE can't be standardized, returns an error
+        :param strict: If true and the CURIE can't be standardized, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the CURIE can't be standardized, return the input.
+            Defaults to false.
         :returns:
             A standardized version of the CURIE in case a prefix synonym was used.
             Note that this function is idempotent, i.e., if you give an already
@@ -1266,8 +1270,9 @@ class Converter:
 
         :param uri:
             A string representing a valid uniform resource identifier (URI)
-        :param strict: If true and the URI can't be standardized, returns an error
+        :param strict: If true and the URI can't be standardized, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the URI can't be standardized, return the input.
+            Defaults to false.
         :returns:
             A standardized version of the URI in case a URI prefix synonym was used.
             Note that this function is idempotent, i.e., if you give an already
@@ -1318,8 +1323,9 @@ class Converter:
         :param df: A pandas DataFrame
         :param column: The column in the dataframe containing URIs to convert to CURIEs.
         :param target_column: The column to put the results in. Defaults to input column.
-        :param strict: If true and the URI can't be compressed, returns an error
+        :param strict: If true and the URI can't be compressed, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the URI can't be compressed, return the input.
+            Defaults to false.
         """
         func = partial(self.compress, strict=strict, passthrough=passthrough)
         df[column if target_column is None else target_column] = df[column].map(func)
@@ -1337,8 +1343,9 @@ class Converter:
         :param df: A pandas DataFrame
         :param column: The column in the dataframe containing CURIEs to convert to URIs.
         :param target_column: The column to put the results in. Defaults to input column.
-        :param strict: If true and the CURIE can't be expanded, returns an error
+        :param strict: If true and the CURIE can't be expanded, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the CURIE can't be expanded, return the input.
+            Defaults to false.
         """
         func = partial(self.expand, strict=strict, passthrough=passthrough)
         df[column if target_column is None else target_column] = df[column].map(func)
@@ -1357,8 +1364,9 @@ class Converter:
         :param df: A pandas DataFrame
         :param column: The column in the dataframe containing prefixes to standardize.
         :param target_column: The column to put the results in. Defaults to input column.
-        :param strict: If true and any prefix can't be standardized, returns an error
+        :param strict: If true and any prefix can't be standardized, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and any prefix can't be standardized, return the input.
+            Defaults to false.
         """
         func = partial(self.standardize_prefix, strict=strict, passthrough=passthrough)
         df[column if target_column is None else target_column] = df[column].map(func)
@@ -1377,8 +1385,9 @@ class Converter:
         :param df: A pandas DataFrame
         :param column: The column in the dataframe containing CURIEs to standardize.
         :param target_column: The column to put the results in. Defaults to input column.
-        :param strict: If true and any CURIE can't be standardized, returns an error
+        :param strict: If true and any CURIE can't be standardized, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and any CURIE can't be standardized, return the input.
+            Defaults to false.
 
         The Disease Ontology curates mappings to other semantic spaces and distributes them in the
         tabular SSSOM format. However, they use a wide variety of non-standard prefixes for referring
@@ -1412,8 +1421,9 @@ class Converter:
         :param df: A pandas DataFrame
         :param column: The column in the dataframe containing URIs to standardize.
         :param target_column: The column to put the results in. Defaults to input column.
-        :param strict: If true and any URI can't be standardized, returns an error
+        :param strict: If true and any URI can't be standardized, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and any URI can't be standardized, return the input.
+            Defaults to false.
         """
         func = partial(self.standardize_uri, strict=strict, passthrough=passthrough)
         df[column if target_column is None else target_column] = df[column].map(func)
@@ -1433,8 +1443,9 @@ class Converter:
         :param column: The column in the dataframe containing URIs to convert to CURIEs.
         :param sep: The delimiter of the CSV file, defaults to tab
         :param header: Does the file have a header row?
-        :param strict: If true and the URI can't be compressed, returns an error
+        :param strict: If true and the URI can't be compressed, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the URI can't be compressed, return the input.
+            Defaults to false.
         """
         func = partial(self.compress, strict=strict, passthrough=passthrough)
         self._file_helper(func, path=path, column=column, sep=sep, header=header)
@@ -1454,8 +1465,9 @@ class Converter:
         :param column: The column in the dataframe containing CURIEs to convert to URIs.
         :param sep: The delimiter of the CSV file, defaults to tab
         :param header: Does the file have a header row?
-        :param strict: If true and the CURIE can't be expanded, returns an error
+        :param strict: If true and the CURIE can't be expanded, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the CURIE can't be expanded, return the input.
+            Defaults to false.
         """
         func = partial(self.expand, strict=strict, passthrough=passthrough)
         self._file_helper(func, path=path, column=column, sep=sep, header=header)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,12 +14,15 @@ import rdflib
 from curies.api import (
     CompressionError,
     Converter,
+    CURIEStandardizationError,
     DuplicatePrefixes,
     DuplicateURIPrefixes,
     ExpansionError,
+    PrefixStandardizationError,
     Record,
     Reference,
     ReferenceTuple,
+    URIStandardizationError,
     chain,
 )
 from curies.sources import (
@@ -442,6 +445,9 @@ class TestConverter(unittest.TestCase):
         self.assertEqual("CHEBI:138488", converter.standardize_curie("chebi:138488"))
         self.assertEqual("CHEBI:138488", converter.standardize_curie("CHEBI:138488"))
         self.assertIsNone(converter.standardize_curie("NOPE:NOPE"))
+        self.assertEqual("NOPE:NOPE", converter.standardize_curie("NOPE:NOPE", passthrough=True))
+        with self.assertRaises(CURIEStandardizationError):
+            converter.standardize_curie("NOPE:NOPE", strict=True)
 
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
@@ -454,6 +460,9 @@ class TestConverter(unittest.TestCase):
             converter.standardize_uri("http://purl.obolibrary.org/obo/CHEBI_138488"),
         )
         self.assertIsNone(converter.standardize_uri("NOPE"))
+        self.assertEqual("NOPE", converter.standardize_uri("NOPE", passthrough=True))
+        with self.assertRaises(URIStandardizationError):
+            converter.standardize_uri("NOPE:NOPE", strict=True)
 
     def test_combine(self):
         """Test chaining converters."""
@@ -585,6 +594,9 @@ class TestConverter(unittest.TestCase):
         self.assertEqual("chebi", converter.standardize_prefix("chebi"))
         self.assertEqual("chebi", converter.standardize_prefix("CHEBI"))
         self.assertIsNone(converter.standardize_prefix("nope"))
+        self.assertEqual("nope", converter.standardize_prefix("nope", passthrough=True))
+        with self.assertRaises(PrefixStandardizationError):
+            converter.standardize_prefix("nope", strict=True)
 
         rows = [
             ("chebi", "CHEBI:1", "http://purl.obolibrary.org/obo/CHEBI_1"),


### PR DESCRIPTION
As a follow-up to #79, this PR adds options for strict and passthrough to standardization