### PR TITLE
Add is_curie and is_uri functions

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -649,6 +649,36 @@ Apply in bulk to a CSV file with :meth:`curies.Converter.file_expand` and
 
 Tools for Developers and Semantic Engineers
 -------------------------------------------
+CURIE and URI Checks
+~~~~~~~~~~~~~~~~~~~~
+Sometimes, it's not clear if data from a given place is a CURIE or a URI. While
+the `SafeCURIE syntax <https://www.w3.org/TR/2010/NOTE-curie-20101216/#P_safe_curie>`_
+is intended to address this, it's often overlooked. Therefore, each :class:`curies.Converter`
+comes with functions for checking if a string is a CURIE (:meth:`curies.Converter.is_curie`)
+or a URI (:meth:`curies.Converter.is_uri`) under its definition.
+
+.. code-block:: python
+
+    import curies
+
+    converter = curies.get_obo_converter()
+
+    >>> converter.is_curie("GO:1234567")
+    True
+    >>> converter.is_curie("http://purl.obolibrary.org/obo/GO_1234567")
+    False
+    # This is a valid CURIE, but not under this converter's definition
+    >>> converter.is_curie("pdb:2gc4")
+    True
+
+    >>> converter.is_uri("http://purl.obolibrary.org/obo/GO_1234567")
+    True
+    >>> converter.is_uri("GO:1234567")
+    False
+    # This is a valid URI, but not under this converter's definition
+    >>> converter.is_uri("http://proteopedia.org/wiki/index.php/2gc4")
+    False
+
 Reusable data structures for references
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 While URIs and CURIEs are often represented as strings, for many programmatic applications,

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -669,7 +669,7 @@ or a URI (:meth:`curies.Converter.is_uri`) under its definition.
     False
     # This is a valid CURIE, but not under this converter's definition
     >>> converter.is_curie("pdb:2gc4")
-    True
+    False
 
     >>> converter.is_uri("http://purl.obolibrary.org/obo/GO_1234567")
     True

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -960,7 +960,7 @@ class Converter:
         """Check if the string can be parsed as a URI by this converter.
 
         :param s: A string that might be a URI
-        :returns: If the string can be parsed as a CURIE by this converter.
+        :returns: If the string can be parsed as a URI by this converter.
             Note that some valid URIs, when passed to this function, will
             result in False if their URI prefixes are not registered with this
             converter.

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -958,8 +958,7 @@ class Converter:
 
     def is_uri(self, uri: str) -> bool:
         """Check if a string is a valid URI based on the records in this converter."""
-        prefix, _ = self.parse_uri(uri)
-        return prefix is not None
+        return self.compress(uri) is not None
 
     def compress_strict(self, uri: str) -> str:
         """Compress a URI to a CURIE, and raise an error of not possible."""
@@ -1047,7 +1046,7 @@ class Converter:
 
     def is_curie(self, curie: str) -> bool:
         """Check if the CURIE is parsable under this converter."""
-        return self.expand(curie) is None
+        return self.expand(curie) is not None
 
     def expand_strict(self, curie: str) -> str:
         """Expand a CURIE to a URI, and raise an error of not possible."""

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -956,6 +956,11 @@ class Converter:
         """Format a prefix and identifier into a CURIE string."""
         return f"{prefix}{self.delimiter}{identifier}"
 
+    def is_uri(self, uri: str) -> bool:
+        """Check if a string is a valid URI based on the records in this converter."""
+        prefix, _ = self.parse_uri(uri)
+        return prefix is not None
+
     def compress_strict(self, uri: str) -> str:
         """Compress a URI to a CURIE, and raise an error of not possible."""
         return self.compress(uri, strict=True)
@@ -1039,6 +1044,10 @@ class Converter:
             return None, None
         else:
             return ReferenceTuple(prefix, uri[len(value) :])
+
+    def is_curie(self, curie: str) -> bool:
+        """Check if the CURIE is parsable under this converter."""
+        return self.expand(curie) is None
 
     def expand_strict(self, curie: str) -> str:
         """Expand a CURIE to a URI, and raise an error of not possible."""

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1086,7 +1086,7 @@ class Converter:
         False.
 
         >>> converter.is_curie("pdb:2gc4")
-        True
+        False
         """
         return self.expand(s) is not None
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -956,9 +956,30 @@ class Converter:
         """Format a prefix and identifier into a CURIE string."""
         return f"{prefix}{self.delimiter}{identifier}"
 
-    def is_uri(self, uri: str) -> bool:
-        """Check if a string is a valid URI based on the records in this converter."""
-        return self.compress(uri) is not None
+    def is_uri(self, s: str) -> bool:
+        """Check if the string can be parsed as a URI by this converter.
+
+        :param s: A string that might be a URI
+        :returns: If the string can be parsed as a CURIE by this converter.
+            Note that some valid URIs, when passed to this function, will
+            result in False if their URI prefixes are not registered with this
+            converter.
+
+        >>> import curies
+        >>> converter = curies.get_obo_converter()
+        >>> converter.is_uri("http://purl.obolibrary.org/obo/GO_1234567")
+        True
+        >>> converter.is_uri("GO:1234567")
+        False
+
+        The following is a valid URI, but the prefix is not registered
+        with the converter based on the OBO Foundry prefix map, so it returns
+        False.
+
+        >>> converter.is_uri("http://proteopedia.org/wiki/index.php/2gc4")
+        False
+        """
+        return self.compress(s) is not None
 
     def compress_strict(self, uri: str) -> str:
         """Compress a URI to a CURIE, and raise an error of not possible."""
@@ -1044,9 +1065,30 @@ class Converter:
         else:
             return ReferenceTuple(prefix, uri[len(value) :])
 
-    def is_curie(self, curie: str) -> bool:
-        """Check if the CURIE is parsable under this converter."""
-        return self.expand(curie) is not None
+    def is_curie(self, s: str) -> bool:
+        """Check if the string can be parsed as a CURIE by this converter.
+
+        :param s: A string that might be a CURIE
+        :returns: If the string can be parsed as a CURIE by this converter.
+            Note that some valid CURIEs, when passed to this function, will
+            result in False if their prefixes are not registered with this
+            converter.
+
+        >>> import curies
+        >>> converter = curies.get_obo_converter()
+        >>> converter.is_curie("GO:1234567")
+        True
+        >>> converter.is_curie("http://purl.obolibrary.org/obo/GO_1234567")
+        False
+
+        The following is a valid CURIE, but the prefix is not registered
+        with the converter based on the OBO Foundry prefix map, so it returns
+        False.
+
+        >>> converter.is_curie("pdb:2gc4")
+        True
+        """
+        return self.expand(s) is not None
 
     def expand_strict(self, curie: str) -> str:
         """Expand a CURIE to a URI, and raise an error of not possible."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -284,6 +284,10 @@ class TestConverter(unittest.TestCase):
             ("CHEBI:1", "http://purl.obolibrary.org/obo/CHEBI_1"),
             ("OBO:unnamespaced", "http://purl.obolibrary.org/obo/unnamespaced"),
         ]:
+            self.assertTrue(converter.is_uri(uri))
+            self.assertTrue(converter.is_curie(curie))
+            self.assertFalse(converter.is_curie(uri))
+            self.assertFalse(converter.is_uri(curie))
             self.assertEqual(curie, converter.compress(uri))
             self.assertEqual(curie, converter.compress_strict(uri))
             self.assertEqual(uri, converter.expand(curie))


### PR DESCRIPTION
Closes #89

## Demo

```python
import curies

converter = curies.get_obo_converter()

>>> converter.is_curie("GO:1234567")
True
>>> converter.is_curie("http://purl.obolibrary.org/obo/GO_1234567")
False

# This is a valid CURIE, but not under this converter's definition
>>> converter.is_curie("pdb:2gc4")
False

>>> converter.is_uri("http://purl.obolibrary.org/obo/GO_1234567")
True
>>> converter.is_uri("GO:1234567")
False

# This is a valid URI, but not under this converter's definition
>>> converter.is_uri("http://proteopedia.org/wiki/index.php/2gc4")
False
```