### PR TITLE
Implement URI or CURIE functionality

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -442,32 +442,17 @@ functions, is upgraded to the preferred prefix, ``GO``.
     >>> converter.standardize_uri('http://amigo.geneontology.org/amigo/term/GO:0032571')
     'http://purl.obolibrary.org/obo/GO_0032571'
 
-Note: non-standard URIs can still be parsed with :meth:`curies.Converter.parse_uri` and compressed
+Note: non-standard URIs (i.e., ones based on URI prefix synonyms) can still be parsed with
+:meth:`curies.Converter.parse_uri` and compressed
 into CURIEs with :meth:`curies.Converter.compress`.
 
 Bulk Operations
 ---------------
-Apply in bulk to a :class:`pandas.DataFrame` with :meth:`curies.Converter.pd_expand` and
-:meth:`curies.Converter.pd_compress`:
+Expansion, compression, and standardization operations can be done in bulk to all rows
+in a :class:`pandas.DataFrame` using the following examples.
 
-.. code-block:: python
-
-    import curies
-    import pandas as pd
-
-    df = pd.read_csv(...)
-    converter = curies.get_obo_converter()
-    converter.pd_compress(df, column=0)
-    converter.pd_expand(df, column=0)
-
-    # standardization operations
-    converter.pd_standardize_prefix(df, column=0)
-    converter.pd_standardize_curie(df, column=0)
-    converter.pd_standardize_uri(df, column=0)
-
-
-Compress URIs
-~~~~~~~~~~~~~
+Bulk Compress URIs
+~~~~~~~~~~~~~~~~~~
 In order to demonstrate bulk operations using :meth:`curies.Converter.pd_compress`,
 we construct a small dataframe:
 
@@ -513,8 +498,11 @@ http://gudt.org/schema/gudt/baseCGSUnitDimensions  http://gudt.org/schema/gudt/b
 http://qudt.org/schema/qudt/conversionMultiplier   http://qudt.org/schema/qudt/conversionMultiplier
 =================================================  =================================================
 
-Expand CURIEs
-~~~~~~~~~~~~~
+The keyword ``ambiguous=True`` can be passed if the source column can either be a CURIE
+or URI. Then, the semantics of compression are used from :meth:`curies.Converter.compress_or_standardize`.
+
+Bulk Expand CURIEs
+~~~~~~~~~~~~~~~~~~
 In order to demonstrate bulk operations using :meth:`curies.Converter.pd_expand`,
 we construct a small dataframe used in conjunction with the OBO converter (which
 only includes OBO Foundry ontology URI prefix expansions):
@@ -579,8 +567,11 @@ GO:0000001       http://purl.obolibrary.org/obo/GO_0000001
 skos:exactMatch  http://www.w3.org/2004/02/skos/core#exactMatch
 ===============  ==============================================
 
-Standardizing Prefixes
-~~~~~~~~~~~~~~~~~~~~~~
+The keyword ``ambiguous=True`` can be passed if the source column can either be a CURIE
+or URI. Then, the semantics of compression are used from :meth:`curies.Converter.compress_or_standardize`.
+
+Bulk Standardizing Prefixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The `Gene Ontology (GO) Annotations Database <https://geneontology.org/docs/go-annotations/>`_
 distributes its file where references to proteins from the `Universal Protein Resource (UniProt)
 <https://www.uniprot.org/>`_ use the prefix ``UniProtKB``. When using the Bioregistry's extended prefix map,
@@ -607,8 +598,8 @@ This can be done in-place with the following:
 
 The ``target_column`` keyword can be given if you don't want to overwrite the original.
 
-Standardizing CURIEs
-~~~~~~~~~~~~~~~~~~~~~~
+Bulk Standardizing CURIEs
+~~~~~~~~~~~~~~~~~~~~~~~~~
 Using the same example data from GO, the sixth column contains CURIE for references such as
 `GO_REF:0000043 <https://bioregistry.io/go.ref:0000043>`_. When using the Bioregistry's extended prefix map,
 these CURIEs' prefixes should be standardized to ``go.ref`` with :meth:`curies.Converter.pd_standardize_curie`.
@@ -646,6 +637,9 @@ Apply in bulk to a CSV file with :meth:`curies.Converter.file_expand` and
     converter.file_compress(path, column=0)
     # modifies file in place
     converter.file_expand(path, column=0)
+
+Like with the Pandas operations, the keyword ``ambiguous=True``` can be set
+when entries can either be CURIEs or URIs.
 
 Tools for Developers and Semantic Engineers
 -------------------------------------------
@@ -687,7 +681,7 @@ or a URI (:meth:`curies.Converter.is_uri`) under its definition.
 
 Extended Expansion and Compression
 **********************************
-The :meth:`curies.Converter.to_uri` extends the CURIE expansion function to handle the situation where
+The :meth:`curies.Converter.expand_or_standardize` extends the CURIE expansion function to handle the situation where
 you might get passed a CURIE or a URI. If it's a CURIE, expansions happen with the normal
 rules. If it's a URI, it tries to standardize it.
 
@@ -704,22 +698,22 @@ rules. If it's a URI, it tries to standardize it.
     ])
 
     # Expand CURIEs
-    >>> converter.to_uri("CHEBI:138488")
+    >>> converter.expand_or_standardize("CHEBI:138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
-    >>> converter.to_uri("chebi:138488")
+    >>> converter.expand_or_standardize("chebi:138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
 
     # standardize URIs
-    >>> converter.to_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
+    >>> converter.expand_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
-    >>> converter.to_uri("https://identifiers.org/chebi:138488")
+    >>> converter.expand_or_standardize("https://identifiers.org/chebi:138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
 
     # Handle cases that aren't valid w.r.t. the converter
-    >>> converter.to_uri("missing:0000000")
-    >>> converter.to_uri("https://example.com/missing:0000000")
+    >>> converter.expand_or_standardize("missing:0000000")
+    >>> converter.expand_or_standardize("https://example.com/missing:0000000")
 
-A similar workflow is implemented in :meth:`curies.Converter.to_curie` for compressing URIs
+A similar workflow is implemented in :meth:`curies.Converter.compress_or_standardize` for compressing URIs
 where a CURIE might get passed.
 
 .. code-block:: python
@@ -735,20 +729,20 @@ where a CURIE might get passed.
     ])
 
     # Compress URIs
-    >>> converter.to_curie("http://purl.obolibrary.org/obo/CHEBI_138488")
+    >>> converter.compress_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488")
     'CHEBI:138488'
-    >>> converter.to_curie("https://identifiers.org/chebi:138488")
+    >>> converter.compress_or_standardize("https://identifiers.org/chebi:138488")
     'CHEBI:138488'
 
     # standardize CURIEs
-    >>> converter.to_curie("CHEBI:138488")
+    >>> converter.compress_or_standardize("CHEBI:138488")
     'CHEBI:138488'
-    >>> converter.to_curie("chebi:138488")
+    >>> converter.compress_or_standardize("chebi:138488")
     'CHEBI:138488'
 
     # Handle cases that aren't valid w.r.t. the converter
-    >>> converter.to_curie("missing:0000000")
-    >>> converter.to_curie("https://example.com/missing:0000000")
+    >>> converter.compress_or_standardize("missing:0000000")
+    >>> converter.compress_or_standardize("https://example.com/missing:0000000")
 
 Reusable data structures for references
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -687,7 +687,7 @@ or a URI (:meth:`curies.Converter.is_uri`) under its definition.
 
 Extended Expansion and Compression
 **********************************
-The :meth:`curies.Converter.expand_ambiguous` extends the CURIE expansion function to handle the situation where
+The :meth:`curies.Converter.to_uri` extends the CURIE expansion function to handle the situation where
 you might get passed a CURIE or a URI. If it's a CURIE, expansions happen with the normal
 rules. If it's a URI, it tries to standardize it.
 
@@ -702,18 +702,18 @@ rules. If it's a URI, it tries to standardize it.
         ),
     ])
 
-    >>> converter.expand_ambiguous("CHEBI:138488")
+    >>> converter.to_uri("CHEBI:138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
 
     # standardize URIs
-    >>> converter.expand_ambiguous("http://purl.obolibrary.org/obo/CHEBI_138488")
+    >>> converter.to_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
-    >>> converter.expand_ambiguous("https://identifiers.org/chebi:138488")
+    >>> converter.to_uri("https://identifiers.org/chebi:138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
 
     # Handle cases that aren't valid w.r.t. the converter
-    >>> converter.expand_ambiguous("missing:0000000")
-    >>> converter.expand_ambiguous("https://example.com/missing:0000000")
+    >>> converter.to_uri("missing:0000000")
+    >>> converter.to_uri("https://example.com/missing:0000000")
 
 A similar workflow can be done for compressing URIs where a CURIE might get passed.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -697,12 +697,16 @@ rules. If it's a URI, it tries to standardize it.
     converter = Converter.from_extended_prefix_map([
         Record(
             prefix="CHEBI",
+            prefix_synonyms=["chebi"],
             uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
             uri_prefix_synonyms=["https://identifiers.org/chebi:"],
         ),
     ])
 
+    # Expand CURIEs
     >>> converter.to_uri("CHEBI:138488")
+    'http://purl.obolibrary.org/obo/CHEBI_138488'
+    >>> converter.to_uri("chebi:138488")
     'http://purl.obolibrary.org/obo/CHEBI_138488'
 
     # standardize URIs

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -687,22 +687,33 @@ or a URI (:meth:`curies.Converter.is_uri`) under its definition.
 
 Extended Expansion and Compression
 **********************************
-The code block below extends the CURIE expansion function to handle the situation where
+The :meth:`curies.Converter.expand_ambiguous` extends the CURIE expansion function to handle the situation where
 you might get passed a CURIE or a URI. If it's a CURIE, expansions happen with the normal
 rules. If it's a URI, it tries to standardize it.
 
 .. code-block:: python
 
-    def expand_ambiguous(converter, uri_or_curie, strict=False, passthrough=False):
-        if converter.is_curie(uri_or_curie):
-            return converter.expand(uri_or_curie)
-        if converter.is_uri(uri_or_curie):
-            return converter.standardize_uri(uri_or_curie)
-        if strict:
-            raise ValueError
-        if passthrough:
-            return uri_or_curie
-        return None
+    from curies import Converter, Record
+    converter = Converter.from_extended_prefix_map([
+        Record(
+            prefix="CHEBI",
+            uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
+            uri_prefix_synonyms=["https://identifiers.org/chebi:"],
+        ),
+    ])
+
+    >>> converter.expand_ambiguous("CHEBI:138488")
+    'http://purl.obolibrary.org/obo/CHEBI_138488'
+
+    # standardize URIs
+    >>> converter.expand_ambiguous("http://purl.obolibrary.org/obo/CHEBI_138488")
+    'http://purl.obolibrary.org/obo/CHEBI_138488'
+    >>> converter.expand_ambiguous("https://identifiers.org/chebi:138488")
+    'http://purl.obolibrary.org/obo/CHEBI_138488'
+
+    # Handle cases that aren't valid w.r.t. the converter
+    >>> converter.expand_ambiguous("missing:0000000")
+    >>> converter.expand_ambiguous("https://example.com/missing:0000000")
 
 A similar workflow can be done for compressing URIs where a CURIE might get passed.
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1615,7 +1615,7 @@ class Converter:
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
         pre_func = self.to_curie if ambiguous else self.compress
-        func = partial(pre_func, strict=strict, passthrough=passthrough)
+        func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         df[column if target_column is None else target_column] = df[column].map(func)
 
     def pd_expand(
@@ -1741,7 +1741,7 @@ class Converter:
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
         pre_func = self.to_curie if ambiguous else self.compress
-        func = partial(pre_func, strict=strict, passthrough=passthrough)
+        func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         self._file_helper(func, path=path, column=column, sep=sep, header=header)
 
     def file_expand(

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1095,14 +1095,14 @@ class Converter:
 
     # docstr-coverage:excused `overload`
     @overload
-    def expand_ambiguous(
+    def to_uri(
         self, uri_or_curie: str, *, strict: Literal[True] = True, passthrough: bool = False
     ) -> str:
         ...
 
     # docstr-coverage:excused `overload`
     @overload
-    def expand_ambiguous(
+    def to_uri(
         self,
         uri_or_curie: str,
         *,
@@ -1113,7 +1113,7 @@ class Converter:
 
     # docstr-coverage:excused `overload`
     @overload
-    def expand_ambiguous(
+    def to_uri(
         self,
         uri_or_curie: str,
         *,
@@ -1122,7 +1122,7 @@ class Converter:
     ) -> Optional[str]:
         ...
 
-    def expand_ambiguous(
+    def to_uri(
         self, uri_or_curie: str, *, strict: bool = False, passthrough: bool = False
     ) -> Optional[str]:
         """Expand a CURIE or standardize a URI.
@@ -1147,14 +1147,14 @@ class Converter:
         ...          uri_prefix_synonyms=["https://identifiers.org/chebi:"],
         ...     ),
         ... ])
-        >>> converter.expand_ambiguous("CHEBI:138488")
+        >>> converter.to_uri("CHEBI:138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
-        >>> converter.expand_ambiguous("http://purl.obolibrary.org/obo/CHEBI_138488")
+        >>> converter.to_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
-        >>> converter.expand_ambiguous("https://identifiers.org/chebi:138488")
+        >>> converter.to_uri("https://identifiers.org/chebi:138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
-        >>> converter.expand_ambiguous("missing:0000000")
-        >>> converter.expand_ambiguous("https://example.com/missing:0000000")
+        >>> converter.to_uri("missing:0000000")
+        >>> converter.to_uri("https://example.com/missing:0000000")
         """
         if self.is_curie(uri_or_curie):
             return self.expand(uri_or_curie, strict=True)
@@ -1551,7 +1551,7 @@ class Converter:
             Defaults to false.
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
-        pre_func = self.expand_ambiguous if ambiguous else self.expand
+        pre_func = self.to_uri if ambiguous else self.expand
         func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         df[column if target_column is None else target_column] = df[column].map(func)
 
@@ -1678,7 +1678,7 @@ class Converter:
             Defaults to false.
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
-        pre_func = self.expand_ambiguous if ambiguous else self.expand
+        pre_func = self.to_uri if ambiguous else self.expand
         func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         self._file_helper(func, path=path, column=column, sep=sep, header=header)
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1143,7 +1143,7 @@ class Converter:
         >>> converter = Converter.from_extended_prefix_map([
         ...     Record(
         ...          prefix="CHEBI",
-        ...          uri_prefix="http://purl.obolibrary.org/obo/CHEBI_138488",
+        ...          uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
         ...          uri_prefix_synonyms=["https://identifiers.org/chebi:"],
         ...     ),
         ... ])

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1042,7 +1042,7 @@ class Converter:
         'CHEBI:138488'
 
         >>> converter.to_curie("CHEBI:138488")
-        'CHEBI:138488'f
+        'CHEBI:138488'
         >>> converter.to_curie("chebi:138488")
         'CHEBI:138488'
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1126,7 +1126,7 @@ class Converter:
         self, uri_or_curie: str, *, strict: bool = False, passthrough: bool = False
     ) -> Optional[str]:
         """Expand a CURIE or standardize a URI.
-        
+
         :param uri_or_curie:
             A string representing a compact URI (CURIE) or a URI.
         :param strict: If true and the string is neither a CURIE that can be expanded nor a URI that can be

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1198,7 +1198,8 @@ class Converter:
             A string representing a compact URI (CURIE)
         :param strict: If true and the CURIE can't be expanded, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the CURIE can't be expanded, return the input.
-            Defaults to false.
+            Defaults to false. If your strings can either be a CURIE _or_ a URI, consider using
+            :meth:`Converter.expand_ambiguous` instead.
         :returns:
             A URI if this converter contains a URI prefix for the prefix in this CURIE
         :raises ExpansionError:

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1143,16 +1143,21 @@ class Converter:
         >>> converter = Converter.from_extended_prefix_map([
         ...     Record(
         ...          prefix="CHEBI",
+        ...          prefix_synonyms=["chebi"],
         ...          uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
         ...          uri_prefix_synonyms=["https://identifiers.org/chebi:"],
         ...     ),
         ... ])
         >>> converter.to_uri("CHEBI:138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
+         >>> converter.to_uri("chebi:138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+
         >>> converter.to_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
         >>> converter.to_uri("https://identifiers.org/chebi:138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
+
         >>> converter.to_uri("missing:0000000")
         >>> converter.to_uri("https://example.com/missing:0000000")
         """

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -983,14 +983,14 @@ class Converter:
 
     # docstr-coverage:excused `overload`
     @overload
-    def to_curie(
+    def compress_or_standardize(
         self, uri_or_curie: str, *, strict: Literal[True] = True, passthrough: bool = False
     ) -> str:
         ...
 
     # docstr-coverage:excused `overload`
     @overload
-    def to_curie(
+    def compress_or_standardize(
         self,
         uri_or_curie: str,
         *,
@@ -1001,7 +1001,7 @@ class Converter:
 
     # docstr-coverage:excused `overload`
     @overload
-    def to_curie(
+    def compress_or_standardize(
         self,
         uri_or_curie: str,
         *,
@@ -1010,7 +1010,7 @@ class Converter:
     ) -> Optional[str]:
         ...
 
-    def to_curie(
+    def compress_or_standardize(
         self, uri_or_curie: str, *, strict: bool = False, passthrough: bool = False
     ) -> Optional[str]:
         """Compress a URI or standardize a CURIE.
@@ -1036,18 +1036,18 @@ class Converter:
         ...          uri_prefix_synonyms=["https://identifiers.org/chebi:"],
         ...     ),
         ... ])
-        >>> converter.to_curie("http://purl.obolibrary.org/obo/CHEBI_138488")
+        >>> converter.compress_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488")
         'CHEBI:138488'
-        >>> converter.to_curie("https://identifiers.org/chebi:138488")
-        'CHEBI:138488'
-
-        >>> converter.to_curie("CHEBI:138488")
-        'CHEBI:138488'
-        >>> converter.to_curie("chebi:138488")
+        >>> converter.compress_or_standardize("https://identifiers.org/chebi:138488")
         'CHEBI:138488'
 
-        >>> converter.to_curie("missing:0000000")
-        >>> converter.to_curie("https://example.com/missing:0000000")
+        >>> converter.compress_or_standardize("CHEBI:138488")
+        'CHEBI:138488'
+        >>> converter.compress_or_standardize("chebi:138488")
+        'CHEBI:138488'
+
+        >>> converter.compress_or_standardize("missing:0000000")
+        >>> converter.compress_or_standardize("https://example.com/missing:0000000")
         """
         if self.is_uri(uri_or_curie):
             return self.compress(uri_or_curie, strict=True)
@@ -1173,16 +1173,16 @@ class Converter:
 
     # docstr-coverage:excused `overload`
     @overload
-    def to_uri(
-        self, uri_or_curie: str, *, strict: Literal[True] = True, passthrough: bool = False
+    def expand_or_standardize(
+        self, curie_or_uri: str, *, strict: Literal[True] = True, passthrough: bool = False
     ) -> str:
         ...
 
     # docstr-coverage:excused `overload`
     @overload
-    def to_uri(
+    def expand_or_standardize(
         self,
-        uri_or_curie: str,
+        curie_or_uri: str,
         *,
         strict: Literal[False] = False,
         passthrough: Literal[True] = True,
@@ -1191,21 +1191,21 @@ class Converter:
 
     # docstr-coverage:excused `overload`
     @overload
-    def to_uri(
+    def expand_or_standardize(
         self,
-        uri_or_curie: str,
+        curie_or_uri: str,
         *,
         strict: Literal[False] = False,
         passthrough: Literal[False] = False,
     ) -> Optional[str]:
         ...
 
-    def to_uri(
-        self, uri_or_curie: str, *, strict: bool = False, passthrough: bool = False
+    def expand_or_standardize(
+        self, curie_or_uri: str, *, strict: bool = False, passthrough: bool = False
     ) -> Optional[str]:
         """Expand a CURIE or standardize a URI.
 
-        :param uri_or_curie:
+        :param curie_or_uri:
             A string representing a compact URI (CURIE) or a URI.
         :param strict: If true and the string is neither a CURIE that can be expanded nor a URI that can be
             standardized, returns an error. Defaults to false.
@@ -1226,27 +1226,27 @@ class Converter:
         ...          uri_prefix_synonyms=["https://identifiers.org/chebi:"],
         ...     ),
         ... ])
-        >>> converter.to_uri("CHEBI:138488")
+        >>> converter.expand_or_standardize("CHEBI:138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
-         >>> converter.to_uri("chebi:138488")
-        'http://purl.obolibrary.org/obo/CHEBI_138488'
-
-        >>> converter.to_uri("http://purl.obolibrary.org/obo/CHEBI_138488")
-        'http://purl.obolibrary.org/obo/CHEBI_138488'
-        >>> converter.to_uri("https://identifiers.org/chebi:138488")
+         >>> converter.expand_or_standardize("chebi:138488")
         'http://purl.obolibrary.org/obo/CHEBI_138488'
 
-        >>> converter.to_uri("missing:0000000")
-        >>> converter.to_uri("https://example.com/missing:0000000")
+        >>> converter.expand_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+        >>> converter.expand_or_standardize("https://identifiers.org/chebi:138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+
+        >>> converter.expand_or_standardize("missing:0000000")
+        >>> converter.expand_or_standardize("https://example.com/missing:0000000")
         """
-        if self.is_curie(uri_or_curie):
-            return self.expand(uri_or_curie, strict=True)
-        if self.is_uri(uri_or_curie):
-            return self.standardize_uri(uri_or_curie, strict=True)
+        if self.is_curie(curie_or_uri):
+            return self.expand(curie_or_uri, strict=True)
+        if self.is_uri(curie_or_uri):
+            return self.standardize_uri(curie_or_uri, strict=True)
         if strict:
-            raise ExpansionError(uri_or_curie)
+            raise ExpansionError(curie_or_uri)
         if passthrough:
-            return uri_or_curie
+            return curie_or_uri
         return None
 
     def expand_strict(self, curie: str) -> str:
@@ -1614,7 +1614,7 @@ class Converter:
             Defaults to false.
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
-        pre_func = self.to_curie if ambiguous else self.compress
+        pre_func = self.compress_or_standardize if ambiguous else self.compress
         func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         df[column if target_column is None else target_column] = df[column].map(func)
 
@@ -1637,7 +1637,7 @@ class Converter:
             Defaults to false.
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
-        pre_func = self.to_uri if ambiguous else self.expand
+        pre_func = self.expand_or_standardize if ambiguous else self.expand
         func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         df[column if target_column is None else target_column] = df[column].map(func)
 
@@ -1740,7 +1740,7 @@ class Converter:
             Defaults to false.
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
-        pre_func = self.to_curie if ambiguous else self.compress
+        pre_func = self.compress_or_standardize if ambiguous else self.compress
         func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         self._file_helper(func, path=path, column=column, sep=sep, header=header)
 
@@ -1766,7 +1766,7 @@ class Converter:
             Defaults to false.
         :param ambiguous: If true, consider the column as containing either CURIEs or URIs.
         """
-        pre_func = self.to_uri if ambiguous else self.expand
+        pre_func = self.expand_or_standardize if ambiguous else self.expand
         func = partial(pre_func, strict=strict, passthrough=passthrough)  # type:ignore
         self._file_helper(func, path=path, column=column, sep=sep, header=header)
 

--- a/src/curies/api.py
+++ b/src/curies/api.py
@@ -1125,7 +1125,37 @@ class Converter:
     def expand_ambiguous(
         self, uri_or_curie: str, *, strict: bool = False, passthrough: bool = False
     ) -> Optional[str]:
-        """Expand a CURIE or standardize a URI."""
+        """Expand a CURIE or standardize a URI.
+        
+        :param uri_or_curie:
+            A string representing a compact URI (CURIE) or a URI.
+        :param strict: If true and the string is neither a CURIE that can be expanded nor a URI that can be
+            standardized, returns an error. Defaults to false.
+        :param passthrough: If true, strict is false, and the string is neither a CURIE that can be expanded
+            nor a URI that can be standardized, return the input. Defaults to false.
+        :returns:
+            If the string is a CURIE, and it can be expanded, returns the corresponding URI.
+            If the string is a URI, and it can be standardized, returns the standard URI.
+        :raises ExpansionError:
+            If strict is true and the CURIE can't be expanded
+
+        >>> from curies import Converter, Record
+        >>> converter = Converter.from_extended_prefix_map([
+        ...     Record(
+        ...          prefix="CHEBI",
+        ...          uri_prefix="http://purl.obolibrary.org/obo/CHEBI_138488",
+        ...          uri_prefix_synonyms=["https://identifiers.org/chebi:"],
+        ...     ),
+        ... ])
+        >>> converter.expand_ambiguous("CHEBI:138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+        >>> converter.expand_ambiguous("http://purl.obolibrary.org/obo/CHEBI_138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+        >>> converter.expand_ambiguous("https://identifiers.org/chebi:138488")
+        'http://purl.obolibrary.org/obo/CHEBI_138488'
+        >>> converter.expand_ambiguous("missing:0000000")
+        >>> converter.expand_ambiguous("https://example.com/missing:0000000")
+        """
         if self.is_curie(uri_or_curie):
             return self.expand(uri_or_curie, strict=True)
         if self.is_uri(uri_or_curie):
@@ -1165,14 +1195,14 @@ class Converter:
         """Expand a CURIE to a URI, if possible.
 
         :param curie:
-            A string representing a compact URI
+            A string representing a compact URI (CURIE)
         :param strict: If true and the CURIE can't be expanded, returns an error. Defaults to false.
         :param passthrough: If true, strict is false, and the CURIE can't be expanded, return the input.
             Defaults to false.
         :returns:
             A URI if this converter contains a URI prefix for the prefix in this CURIE
         :raises ExpansionError:
-            If struct is true and the URI can't be expanded
+            If strict is true and the CURIE can't be expanded
 
         >>> from curies import Converter
         >>> converter = Converter.from_prefix_map({

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -777,32 +777,36 @@ class TestConverter(unittest.TestCase):
         )
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
-            converter.to_uri("CHEBI:138488"),
+            converter.expand_or_standardize("CHEBI:138488"),
         )
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
-            converter.to_uri("chebi:138488"),
+            converter.expand_or_standardize("chebi:138488"),
         )
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
-            converter.to_uri("http://purl.obolibrary.org/obo/CHEBI_138488"),
+            converter.expand_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488"),
         )
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
-            converter.to_uri("https://identifiers.org/chebi:138488"),
+            converter.expand_or_standardize("https://identifiers.org/chebi:138488"),
         )
 
-        self.assertIsNone(converter.to_uri("missing:0000000"))
+        self.assertIsNone(converter.expand_or_standardize("missing:0000000"))
         with self.assertRaises(ExpansionError):
-            converter.to_uri("missing:0000000", strict=True)
-        self.assertEqual("missing:0000000", converter.to_uri("missing:0000000", passthrough=True))
+            converter.expand_or_standardize("missing:0000000", strict=True)
+        self.assertEqual(
+            "missing:0000000", converter.expand_or_standardize("missing:0000000", passthrough=True)
+        )
 
-        self.assertIsNone(converter.to_uri("https://example.com/missing:0000000"))
+        self.assertIsNone(converter.expand_or_standardize("https://example.com/missing:0000000"))
         with self.assertRaises(ExpansionError):
-            converter.to_uri("https://example.com/missing:0000000", strict=True)
+            converter.expand_or_standardize("https://example.com/missing:0000000", strict=True)
         self.assertEqual(
             "https://example.com/missing:0000000",
-            converter.to_uri("https://example.com/missing:0000000", passthrough=True),
+            converter.expand_or_standardize(
+                "https://example.com/missing:0000000", passthrough=True
+            ),
         )
 
     def test_compress_ambiguous(self):
@@ -817,24 +821,32 @@ class TestConverter(unittest.TestCase):
                 ),
             ]
         )
-        self.assertEqual("CHEBI:138488", converter.to_curie("CHEBI:138488"))
-        self.assertEqual("CHEBI:138488", converter.to_curie("chebi:138488"))
+        self.assertEqual("CHEBI:138488", converter.compress_or_standardize("CHEBI:138488"))
+        self.assertEqual("CHEBI:138488", converter.compress_or_standardize("chebi:138488"))
         self.assertEqual(
-            "CHEBI:138488", converter.to_curie("http://purl.obolibrary.org/obo/CHEBI_138488")
+            "CHEBI:138488",
+            converter.compress_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488"),
         )
-        self.assertEqual("CHEBI:138488", converter.to_curie("https://identifiers.org/chebi:138488"))
+        self.assertEqual(
+            "CHEBI:138488",
+            converter.compress_or_standardize("https://identifiers.org/chebi:138488"),
+        )
 
-        self.assertIsNone(converter.to_uri("missing:0000000"))
+        self.assertIsNone(converter.expand_or_standardize("missing:0000000"))
         with self.assertRaises(ExpansionError):
-            converter.to_uri("missing:0000000", strict=True)
-        self.assertEqual("missing:0000000", converter.to_uri("missing:0000000", passthrough=True))
+            converter.expand_or_standardize("missing:0000000", strict=True)
+        self.assertEqual(
+            "missing:0000000", converter.expand_or_standardize("missing:0000000", passthrough=True)
+        )
 
-        self.assertIsNone(converter.to_uri("https://example.com/missing:0000000"))
+        self.assertIsNone(converter.expand_or_standardize("https://example.com/missing:0000000"))
         with self.assertRaises(ExpansionError):
-            converter.to_uri("https://example.com/missing:0000000", strict=True)
+            converter.expand_or_standardize("https://example.com/missing:0000000", strict=True)
         self.assertEqual(
             "https://example.com/missing:0000000",
-            converter.to_uri("https://example.com/missing:0000000", passthrough=True),
+            converter.expand_or_standardize(
+                "https://example.com/missing:0000000", passthrough=True
+            ),
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -763,6 +763,45 @@ class TestConverter(unittest.TestCase):
         )
         self.assertIsNone(converter.expand_all("NOPE:NOPE"))
 
+    def test_expand_ambiguous(self):
+        """Test expansion of URI or CURIEs."""
+        converter = Converter.from_extended_prefix_map(
+            [
+                Record(
+                    prefix="CHEBI",
+                    uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
+                    uri_prefix_synonyms=["https://identifiers.org/chebi:"],
+                ),
+            ]
+        )
+        self.assertEqual(
+            "http://purl.obolibrary.org/obo/CHEBI_138488",
+            converter.expand_ambiguous("CHEBI:138488"),
+        )
+        self.assertEqual(
+            "http://purl.obolibrary.org/obo/CHEBI_138488",
+            converter.expand_ambiguous("http://purl.obolibrary.org/obo/CHEBI_138488"),
+        )
+        self.assertEqual(
+            "http://purl.obolibrary.org/obo/CHEBI_138488",
+            converter.expand_ambiguous("https://identifiers.org/chebi:138488"),
+        )
+
+        self.assertIsNone(converter.expand_ambiguous("missing:0000000"))
+        with self.assertRaises(ExpansionError):
+            converter.expand_ambiguous("missing:0000000", strict=True)
+        self.assertEqual(
+            "missing:0000000", converter.expand_ambiguous("missing:0000000", passthrough=True)
+        )
+
+        self.assertIsNone(converter.expand_ambiguous("https://example.com/missing:0000000"))
+        with self.assertRaises(ExpansionError):
+            converter.expand_ambiguous("https://example.com/missing:0000000", strict=True)
+        self.assertEqual(
+            "https://example.com/missing:0000000",
+            converter.expand_ambiguous("https://example.com/missing:0000000", passthrough=True),
+        )
+
 
 class TestVersion(unittest.TestCase):
     """Trivially test a version."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -776,30 +776,30 @@ class TestConverter(unittest.TestCase):
         )
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
-            converter.expand_ambiguous("CHEBI:138488"),
+            converter.to_uri("CHEBI:138488"),
         )
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
-            converter.expand_ambiguous("http://purl.obolibrary.org/obo/CHEBI_138488"),
+            converter.to_uri("http://purl.obolibrary.org/obo/CHEBI_138488"),
         )
         self.assertEqual(
             "http://purl.obolibrary.org/obo/CHEBI_138488",
-            converter.expand_ambiguous("https://identifiers.org/chebi:138488"),
+            converter.to_uri("https://identifiers.org/chebi:138488"),
         )
 
-        self.assertIsNone(converter.expand_ambiguous("missing:0000000"))
+        self.assertIsNone(converter.to_uri("missing:0000000"))
         with self.assertRaises(ExpansionError):
-            converter.expand_ambiguous("missing:0000000", strict=True)
+            converter.to_uri("missing:0000000", strict=True)
         self.assertEqual(
-            "missing:0000000", converter.expand_ambiguous("missing:0000000", passthrough=True)
+            "missing:0000000", converter.to_uri("missing:0000000", passthrough=True)
         )
 
-        self.assertIsNone(converter.expand_ambiguous("https://example.com/missing:0000000"))
+        self.assertIsNone(converter.to_uri("https://example.com/missing:0000000"))
         with self.assertRaises(ExpansionError):
-            converter.expand_ambiguous("https://example.com/missing:0000000", strict=True)
+            converter.to_uri("https://example.com/missing:0000000", strict=True)
         self.assertEqual(
             "https://example.com/missing:0000000",
-            converter.expand_ambiguous("https://example.com/missing:0000000", passthrough=True),
+            converter.to_uri("https://example.com/missing:0000000", passthrough=True),
         )
 
 


### PR DESCRIPTION
The `Converter.expand` function turns a CURIE into a URI. This PR implements `Converter.expand_or_standardize`, which works like the normal `Converter.expand`, but if a URI is given, then it standardizes it and returns it. The other mechanics for "strict" and "passthrough" work the same.

This PR also implements `Converter.compress_or_standardize` as a counterpart for `Converter.compress`

## Demo

The expansion and compression demos use a very simple extended prefix map:

```python
from curies import Converter, Record

converter = Converter.from_extended_prefix_map([
    Record(
        prefix="CHEBI",
        prefix_synonyms=["chebi"],
        uri_prefix="http://purl.obolibrary.org/obo/CHEBI_",
        uri_prefix_synonyms=["https://identifiers.org/chebi:"],
    ),
])
```

### Expansion

```python
# Expand CURIEs
>>> converter.expand_or_standardize("CHEBI:138488")
'http://purl.obolibrary.org/obo/CHEBI_138488'
>>> converter.expand_or_standardize("chebi:138488")
'http://purl.obolibrary.org/obo/CHEBI_138488'

# Standardize URIs
>>> converter.expand_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488")
'http://purl.obolibrary.org/obo/CHEBI_138488'
>>> converter.expand_or_standardize("https://identifiers.org/chebi:138488")
'http://purl.obolibrary.org/obo/CHEBI_138488'

# Handle cases that aren't valid w.r.t. the converter
>>> converter.expand_or_standardize("missing:0000000")
>>> converter.expand_or_standardize("https://example.com/missing:0000000")
```


### Compression

```python
# Compress URIs
>>> converter.compress_or_standardize("http://purl.obolibrary.org/obo/CHEBI_138488")
'CHEBI:138488'
>>> converter.compress_or_standardize("https://identifiers.org/chebi:138488")
'CHEBI:138488'

# Standardize CURIEs
>>> converter.compress_or_standardize("CHEBI:138488")
'CHEBI:138488'
>>> converter.compress_or_standardize("chebi:138488")
'CHEBI:138488'

# Handle cases that aren't valid w.r.t. the converter
>>> converter.compress_or_standardize("missing:0000000")
>>> converter.compress_or_standardize("https://example.com/missing:0000000")
````

## Known Use Cases

- Projects like LinkML that do not often make distinctions between URIs and CURIEs being in the same field would be able to use this functionality nicely
- SSSOM-py also implements its own version of this function https://github.com/mapping-commons/sssom-py/blob/ad70a83fb513e3d84a186bd500017471c4c9f7be/src/sssom/util.py#L1488-L1504 that can be replaced.
- Data science workflows that have started relying on "passthrough=True" could better use these updated functions to be more careful about keeping content that is valid w.r.t. the prefix map and also standardized.

## TODO

- [x] I am looking for a better name for this before merging it.
- [x] Add docs for bulk operations
- [x] Add corresponding compress operation (after picking a better nomenclature)