### PR TITLE
Add discovery algorithm

### DIFF
--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -1,2 +1,3 @@
 URI Prefix Discovery
 ====================
+.. todo:: write docs on :func:`curies.discover`

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -26,10 +26,8 @@ Here, we use :func:`curies.discover_from_rdf` to load an ontology in the RDF/XML
 
     discovered_converter = curies.discover_from_rdf(
         converter,
-        graph=ONTOLOGY_URL,
-        graph_format="xml",
-        delimiters="#/_",
-        cutoff=5,
+        ONTOLOGY_URL,
+        format="xml",
     )
 
     rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]
@@ -37,16 +35,66 @@ Here, we use :func:`curies.discover_from_rdf` to load an ontology in the RDF/XML
 
 Results in:
 
-==============  ====================================================================
+==============  ==============================================================================
 curie_prefix    uri_prefix
-==============  ====================================================================
+==============  ==============================================================================
+ns1             ``http://ontologydesignpatterns.org/wiki/Community:Parts_and_``
+ns10            ``http://wiki.geneontology.org/index.php/Involved_``
+ns11            ``https://en.wikipedia.org/wiki/Allen%27s_interval_``
+ns12            ``https://groups.google.com/d/msg/bfo-owl-devel/s9Uug5QmAws/ZDRnpiIi_``
+ns13            ``https://ror.org/``
+ns14            ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``
+ns15            ``https://w3id.org/seo#``
+ns16            ``https://www.confident-conference.org/index.php/Academic_Field:Information_``
+ns17            ``https://www.confident-conference.org/index.php/Event:VIVO_``
+ns18            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``
+ns19            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_orga_``
+ns2             ``http://protege.stanford.edu/plugins/owl/protege#``
+ns20            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``
+ns21            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``
+ns22            ``https://www.confident-conference.org/index.php/Event_Series:VIVO_``
+ns23            ``https://www.wikidata.org/wiki/``
+ns24            ``https://www.wikidata.org/wiki/Wikidata:Property_proposal/colocated_``
+ns25            ``urn:swrl#``
+ns3             ``http://purl.obolibrary.org/obo/AEON_``
+ns4             ``http://purl.obolibrary.org/obo/bfo/axiom/``
+ns5             ``http://purl.obolibrary.org/obo/valid_for_``
+ns6             ``http://purl.obolibrary.org/obo/valid_for_go_``
+ns7             ``http://purl.obolibrary.org/obo/valid_for_go_annotation_``
+ns8             ``http://purl.obolibrary.org/obo/wikiCFP_``
+ns9             ``http://usefulinc.com/ns/doap#``
+==============  ==============================================================================
+
+There are several URI prefixes that feel like false positives, so let's set a cutoff of a minimum
+of 2 appearances for it to make it.
+
+.. code-block:: python
+
+    discovered_converter = curies.discover_from_rdf(
+        converter,
+        ONTOLOGY_URL,
+        format="xml",
+        cutoff=2,
+    )
+
+    rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]
+    print(tabulate(rows, headers=["curie_prefix", "uri_prefix"], tablefmt="rst"))
+
+Now, the list is much shorter and more managable, but there still appear to be false positives.
+
+==============  =========================================================================
+curie_prefix    uri_prefix
+==============  =========================================================================
 ns1             ``http://purl.obolibrary.org/obo/AEON_``
 ns2             ``http://purl.obolibrary.org/obo/bfo/axiom/``
-ns3             ``https://github.com/tibonto/aeon/issues/``
+ns3             ``http://purl.obolibrary.org/obo/valid_for_go_``
 ns4             ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``
 ns5             ``https://w3id.org/seo#``
 ns6             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``
-==============  ====================================================================
+ns7             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``
+ns8             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``
+ns9             ``urn:swrl#``
+==============  =========================================================================
 
 .. note::
 

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -8,6 +8,7 @@ URI Prefix Discovery
 Discovering URI Prefixes from an Ontology
 -----------------------------------------
 A common place where discovering URI prefixes is important is when working with new ontologies.
+Here, we use :func:`curies.discover_from_rdf` to load an ontology in the RDF/XML format.
 
 .. code-block:: python
 

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -165,21 +165,31 @@ of two appearances of a URI prefix to reduce the most spurious false positives.
     )
 
 We have reduced the list to a manageable set of 9 putative URI prefixes in the following table.
-This table is annotated with manual curation in the "call" column
 
-==============  =========================================================================  ================================================================================================================================================
-curie_prefix    uri_prefix                                                                 Call
-==============  =========================================================================  ================================================================================================================================================
-ns1             ``http://purl.obolibrary.org/obo/AEON_``                                   Represents the AEON vocabulary itself. Should be given the ``aeon`` prefix.
-ns2             ``http://purl.obolibrary.org/obo/bfo/axiom/``                              False positive
-ns3             ``http://purl.obolibrary.org/obo/valid_for_go_``                           False positive
-ns4             ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``       Represents the `Conference Ontology <https://bioregistry.io/conference>`_. Should be given the ``conference`` prefix.
-ns5             ``https://w3id.org/seo#``                                                  Represents the `Scientific Event Ontology (SEO) <https://bioregistry.io/seo>`_. Should be given the ``seo`` prefix.
-ns6             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``        False positive
-ns7             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``  False positive
-ns8             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``  False positive
-ns9             ``urn:swrl#``                                                              Represents the `Semantic Web Rule Language <https://bioregistry.io/registry/swrl>`_, though using URNs is an interesting choice in serialization
-==============  =========================================================================  ================================================================================================================================================
+==============  =========================================================================
+curie_prefix    uri_prefix
+==============  =========================================================================
+ns1             ``http://purl.obolibrary.org/obo/AEON_``
+ns2             ``http://purl.obolibrary.org/obo/bfo/axiom/``
+ns3             ``http://purl.obolibrary.org/obo/valid_for_go_``
+ns4             ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``
+ns5             ``https://w3id.org/seo#``
+ns6             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``
+ns7             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``
+ns8             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``
+ns9             ``urn:swrl#``
+==============  =========================================================================
+
+Here are the calls to be made:
+
+- ``ns1`` represents the AEON vocabulary itself and should be given the ``aeon`` prefix.
+- ``ns2``, ``ns3``, ``ns6``, ``ns7`, and ``ns8`` are all false positives
+- ``ns4`` represents the `Conference Ontology <https://bioregistry.io/conference>`_ and
+  should be given the ``conference`` prefix.
+- ``ns5`` represents the `Scientific Event Ontology (SEO) <https://bioregistry.io/seo>`_ and
+  should be given the ``seo`` prefix.
+- ``ns9`` represents the `Semantic Web Rule Language <https://bioregistry.io/registry/swrl>`_,
+  though using URNs is an interesting choice in serialization.
 
 After we've made these calls, it's a good idea to write an (extended) prefix map. In this case, since we aren't working
 with CURIE prefix synonyms nor URI prefix synonyms, it's okay to write a simple prefix map or a JSON-LD context without

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -1,44 +1,127 @@
 URI Prefix Discovery
 ====================
-.. warning::
-
-    This tutorial introduces tools that enable you to be a bad Semantic Citizen!
-    Use these tools at your own peril.
+.. automodule:: curies.discovery
 
 Discovering URI Prefixes from an Ontology
 -----------------------------------------
 A common place where discovering URI prefixes is important is when working with new ontologies.
-Here, we use :func:`curies.discover_from_rdf` to load an ontology in the RDF/XML format.
+In the following example, we look at the `Academic Event Ontology (AEON) <https://bioregistry.io/aeon>`_. This
+is an ontology developed under OBO Foundry principles describing academic events. Accordingly, it includes many
+URI references to terms in OBO Foundry ontologies.
+
+In this tutorial, we use :func:`curies.discover_from_rdf` to load the ontology in the RDF/XML format and
+discover putative URI prefixes.
 
 .. code-block:: python
 
     import curies
-    from tabulate import tabulate
+
+    ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
+    discovered_converter = curies.discover_from_rdf(ONTOLOGY_URL, format="xml")
+
+We discovered the fifty URI prefixes in the following table. Many of them appear to be OBO Foundry URI prefixes or
+semantic web prefixes, so in the next step, we'll use prior knowledge to reduce the false discovery rate.
+
+==============  ==============================================================================
+curie_prefix    uri_prefix
+==============  ==============================================================================
+ns1             ``http://ontologydesignpatterns.org/wiki/Community:Parts_and_``
+ns2             ``http://protege.stanford.edu/plugins/owl/protege#``
+ns3             ``http://purl.obolibrary.org/obo/AEON_``
+ns4             ``http://purl.obolibrary.org/obo/APOLLO_SV_``
+ns5             ``http://purl.obolibrary.org/obo/BFO_``
+ns6             ``http://purl.obolibrary.org/obo/CRO_``
+ns7             ``http://purl.obolibrary.org/obo/ENVO_``
+ns8             ``http://purl.obolibrary.org/obo/IAO_``
+ns9             ``http://purl.obolibrary.org/obo/ICO_``
+ns10            ``http://purl.obolibrary.org/obo/NCBITaxon_``
+ns11            ``http://purl.obolibrary.org/obo/OBIB_``
+ns12            ``http://purl.obolibrary.org/obo/OBI_``
+ns13            ``http://purl.obolibrary.org/obo/OMO_``
+ns14            ``http://purl.obolibrary.org/obo/OOSTT_``
+ns15            ``http://purl.obolibrary.org/obo/RO_``
+ns16            ``http://purl.obolibrary.org/obo/TXPO_``
+ns17            ``http://purl.obolibrary.org/obo/bfo/axiom/``
+ns18            ``http://purl.obolibrary.org/obo/valid_for_``
+ns19            ``http://purl.obolibrary.org/obo/valid_for_go_``
+ns20            ``http://purl.obolibrary.org/obo/valid_for_go_annotation_``
+ns21            ``http://purl.obolibrary.org/obo/wikiCFP_``
+ns22            ``http://purl.org/dc/elements/1.1/``
+ns23            ``http://purl.org/dc/terms/``
+ns24            ``http://usefulinc.com/ns/doap#``
+ns25            ``http://wiki.geneontology.org/index.php/Involved_``
+ns26            ``http://www.geneontology.org/formats/oboInOwl#``
+ns27            ``http://www.geneontology.org/formats/oboInOwl#created_``
+ns28            ``http://www.w3.org/1999/02/22-rdf-syntax-ns#``
+ns29            ``http://www.w3.org/2000/01/rdf-schema#``
+ns30            ``http://www.w3.org/2001/XMLSchema#``
+ns31            ``http://www.w3.org/2002/07/owl#``
+ns32            ``http://www.w3.org/2003/11/swrl#``
+ns33            ``http://www.w3.org/2004/02/skos/core#``
+ns34            ``http://www.w3.org/ns/prov#``
+ns35            ``http://xmlns.com/foaf/0.1/``
+ns36            ``https://en.wikipedia.org/wiki/Allen%27s_interval_``
+ns37            ``https://groups.google.com/d/msg/bfo-owl-devel/s9Uug5QmAws/ZDRnpiIi_``
+ns38            ``https://ror.org/``
+ns39            ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``
+ns40            ``https://w3id.org/seo#``
+ns41            ``https://www.confident-conference.org/index.php/Academic_Field:Information_``
+ns42            ``https://www.confident-conference.org/index.php/Event:VIVO_``
+ns43            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``
+ns44            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_orga_``
+ns45            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``
+ns46            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``
+ns47            ``https://www.confident-conference.org/index.php/Event_Series:VIVO_``
+ns48            ``https://www.wikidata.org/wiki/``
+ns49            ``https://www.wikidata.org/wiki/Wikidata:Property_proposal/colocated_``
+ns50            ``urn:swrl#``
+==============  ==============================================================================
+
+In the following block, we chain together (extended) prefix maps from the OBO Foundry as well as
+a "semantic web" prefix map to try and reduce the number of false positives by passing them
+through the ``converter`` keyword argument.
+
+.. code-block:: python
+
+    import curies
 
     ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
     SEMWEB_URL = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/semweb.context.jsonld"
 
-    # Load up some pre-registered context
     converter = curies.chain([
         curies.load_jsonld_context(SEMWEB_URL),
         curies.get_obo_converter(),
     ])
 
     discovered_converter = curies.discover_from_rdf(
-        ONTOLOGY_URL,
-        format="xml",
-        converter=converter,
+        ONTOLOGY_URL, format="xml", converter=converter,
     )
 
-    rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]
-    print(tabulate(rows, headers=["curie_prefix", "uri_prefix"], tablefmt="rst"))
+We reduced the number of putative URI prefixes in half in the following table. However, we can still identify
+some putative URI prefixes that likely would have appeared in a more comprehensive (extended) prefix map such
+as the Bioregistry such as:
 
-Results in:
+- ``https://ror.org/`` for the `Research Organization Registry (ROR) <https://bioregistry.io/ror>`_
+- ``https://w3id.org/seo#`` for the `Scientific Event Ontology (SEO) <https://bioregistry.io/seo>`_
+- ``http://usefulinc.com/ns/doap#`` for the `Description of a Project (DOAP) vocabulary <https://bioregistry.io/doap>`_
+
+Despite this, we're on our way! It's also obvious that several of the remaining putative URI prefixes come from
+non-standard usage of the OBO PURL system (e.g., ``http://purl.obolibrary.org/obo/valid_for_go_annotation_``)
+and some are proper false positives due to using ``_`` as a delimiter
+(e.g., ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``).
 
 ==============  ==============================================================================
 curie_prefix    uri_prefix
 ==============  ==============================================================================
 ns1             ``http://ontologydesignpatterns.org/wiki/Community:Parts_and_``
+ns2             ``http://protege.stanford.edu/plugins/owl/protege#``
+ns3             ``http://purl.obolibrary.org/obo/AEON_``
+ns4             ``http://purl.obolibrary.org/obo/bfo/axiom/``
+ns5             ``http://purl.obolibrary.org/obo/valid_for_``
+ns6             ``http://purl.obolibrary.org/obo/valid_for_go_``
+ns7             ``http://purl.obolibrary.org/obo/valid_for_go_annotation_``
+ns8             ``http://purl.obolibrary.org/obo/wikiCFP_``
+ns9             ``http://usefulinc.com/ns/doap#``
 ns10            ``http://wiki.geneontology.org/index.php/Involved_``
 ns11            ``https://en.wikipedia.org/wiki/Allen%27s_interval_``
 ns12            ``https://groups.google.com/d/msg/bfo-owl-devel/s9Uug5QmAws/ZDRnpiIi_``
@@ -49,54 +132,96 @@ ns16            ``https://www.confident-conference.org/index.php/Academic_Field:
 ns17            ``https://www.confident-conference.org/index.php/Event:VIVO_``
 ns18            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``
 ns19            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_orga_``
-ns2             ``http://protege.stanford.edu/plugins/owl/protege#``
 ns20            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``
 ns21            ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``
 ns22            ``https://www.confident-conference.org/index.php/Event_Series:VIVO_``
 ns23            ``https://www.wikidata.org/wiki/``
 ns24            ``https://www.wikidata.org/wiki/Wikidata:Property_proposal/colocated_``
 ns25            ``urn:swrl#``
-ns3             ``http://purl.obolibrary.org/obo/AEON_``
-ns4             ``http://purl.obolibrary.org/obo/bfo/axiom/``
-ns5             ``http://purl.obolibrary.org/obo/valid_for_``
-ns6             ``http://purl.obolibrary.org/obo/valid_for_go_``
-ns7             ``http://purl.obolibrary.org/obo/valid_for_go_annotation_``
-ns8             ``http://purl.obolibrary.org/obo/wikiCFP_``
-ns9             ``http://usefulinc.com/ns/doap#``
 ==============  ==============================================================================
 
-There are several URI prefixes that feel like false positives, so let's set a cutoff of a minimum
-of 2 appearances for it to make it.
+As a final step in our iterative journey of URI prefix discovery, we're going to use a cutoff for a minimum
+of two appearances of a URI prefix to reduce the most spurious false positives.
 
 .. code-block:: python
 
+    import curies
+
+    ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
+    SEMWEB_URL = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/semweb.context.jsonld"
+
+    converter = curies.chain([
+        curies.load_jsonld_context(SEMWEB_URL),
+        curies.get_obo_converter(),
+    ])
+
     discovered_converter = curies.discover_from_rdf(
-        ONTOLOGY_URL,
-        format="xml",
-        cutoff=2,
-        converter=converter,
+        ONTOLOGY_URL, format="xml", converter=converter, cutoff=2
     )
 
-    rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]
-    print(tabulate(rows, headers=["curie_prefix", "uri_prefix"], tablefmt="rst"))
+We have reduced the list to a manageable set of 9 putative URI prefixes in the following table.
+This table is annotated with manual curation in the "call" column
 
-Now, the list is much shorter and more managable, but there still appear to be false positives.
+==============  =========================================================================  ================================================================================================================================================
+curie_prefix    uri_prefix                                                                 Call
+==============  =========================================================================  ================================================================================================================================================
+ns1             ``http://purl.obolibrary.org/obo/AEON_``                                   Represents the AEON vocabulary itself. Should be given the ``aeon`` prefix.
+ns2             ``http://purl.obolibrary.org/obo/bfo/axiom/``                              False positive
+ns3             ``http://purl.obolibrary.org/obo/valid_for_go_``                           False positive
+ns4             ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``       Represents the `Conference Ontology <https://bioregistry.io/conference>`_. Should be given the ``conference`` prefix.
+ns5             ``https://w3id.org/seo#``                                                  Represents the `Scientific Event Ontology (SEO) <https://bioregistry.io/seo>`_. Should be given the ``seo`` prefix.
+ns6             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``        False positive
+ns7             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``  False positive
+ns8             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``  False positive
+ns9             ``urn:swrl#``                                                              Represents the `Semantic Web Rule Language <https://bioregistry.io/registry/swrl>`_, though using URNs is an interesting choice in serialization
+==============  =========================================================================  ================================================================================================================================================
 
-==============  =========================================================================
-curie_prefix    uri_prefix
-==============  =========================================================================
-ns1             ``http://purl.obolibrary.org/obo/AEON_``
-ns2             ``http://purl.obolibrary.org/obo/bfo/axiom/``
-ns3             ``http://purl.obolibrary.org/obo/valid_for_go_``
-ns4             ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``
-ns5             ``https://w3id.org/seo#``
-ns6             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``
-ns7             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk1_``
-ns8             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_talk2_``
-ns9             ``urn:swrl#``
-==============  =========================================================================
+After we've made these calls, it's a good idea to write an (extended) prefix map. In this case, since we aren't working
+with CURIE prefix synonyms nor URI prefix synonyms, it's okay to write a simple prefix map or a JSON-LD context without
+losing information.
 
 .. note::
 
-    An alternative to discovering new prefixes is often to supplement your project-specific (extended)
-    prefix map with a comprehensive one, such as The Bioregistry.
+    Postscript: throughout this guide, we used the following Python code to create the RST tables:
+
+   .. code-block:: python
+
+      def print_converter(converter) -> None:
+          from tabulate import tabulate
+          rows = sorted(
+              [
+                  (record.prefix, f"``{record.uri_prefix}``")
+                  for record in discovered_converter.records
+              ],
+              key=lambda t: int(t[0].removeprefix("ns")),
+          )
+          print(tabulate(rows, headers=["curie_prefix", "uri_prefix"], tablefmt="rst"))
+
+Just Make It Work, or, A Guide to Being a Questionable Semantic Citizen
+-----------------------------------------------------------------------
+The goal of the :mod:`curies` package is to provide the tools towards making semantically well-defined data,
+which has a meaningful (extended) prefix map associated with it. Maybe you're in an organization that doesn't really
+care about the utility of nice prefix maps, and just wants to get the job done where you need to turn URIs into _some_
+CURIEs.
+
+Here's a recipe for doing this, based on the last example with AEON:
+
+.. code-block:: python
+
+    import curies
+
+    ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
+
+    # Use the Bioregistry as a base prefix since it's the most comprehensive one
+    base_converter = curies.get_bioregistry_converter()
+
+    # Only discover what the Bioregistry doesn't already have
+    discovered_converter = curies.discover_from_rdf(
+        ONTOLOGY_URL, format="xml", converter=base_converter
+    )
+
+    # Chain together the base converter with the discoveries
+    augmented_converter = curies.chain([base_converter, discovered_converter])
+
+With the augmented converter, you can now convert all URIs in the ontology into CURIEs. They will have a smattering
+of unintelligible prefixes with no meaning, but at least the job is done!

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -9,15 +9,20 @@ In the following example, we look at the `Academic Event Ontology (AEON) <https:
 is an ontology developed under OBO Foundry principles describing academic events. Accordingly, it includes many
 URI references to terms in OBO Foundry ontologies.
 
-In this tutorial, we use :func:`curies.discover_from_rdf` to load the ontology in the RDF/XML format and
-discover putative URI prefixes.
+In this tutorial, we use :func:`curies.discover` (and then :func:`curies.discover_from_rdf` as a nice convenience
+function) to load the ontology in the RDF/XML format and discover putative URI prefixes.
 
 .. code-block:: python
 
     import curies
+    from curies.discovery import get_uris_from_rdf
 
     ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
-    discovered_converter = curies.discover_from_rdf(ONTOLOGY_URL, format="xml")
+
+    uris = get_uris_from_rdf(ONTOLOGY_URL, format="xml")
+    discovered_converter = curies.discover(uris)
+    # note, these two steps can be combine with curies.discover_from_rdf,
+    # and we'll do that in the following examples
 
 We discovered the fifty URI prefixes in the following table. Many of them appear to be OBO Foundry URI prefixes or
 semantic web prefixes, so in the next step, we'll use prior knowledge to reduce the false discovery rate.
@@ -94,7 +99,7 @@ through the ``converter`` keyword argument.
     ])
 
     discovered_converter = curies.discover_from_rdf(
-        ONTOLOGY_URL, format="xml", converter=converter,
+        ONTOLOGY_URL, format="xml", converter=converter
     )
 
 We reduced the number of putative URI prefixes in half in the following table. However, we can still identify

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -25,9 +25,9 @@ Here, we use :func:`curies.discover_from_rdf` to load an ontology in the RDF/XML
     ])
 
     discovered_converter = curies.discover_from_rdf(
-        converter,
         ONTOLOGY_URL,
         format="xml",
+        converter=converter,
     )
 
     rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]
@@ -71,10 +71,10 @@ of 2 appearances for it to make it.
 .. code-block:: python
 
     discovered_converter = curies.discover_from_rdf(
-        converter,
         ONTOLOGY_URL,
         format="xml",
         cutoff=2,
+        converter=converter,
     )
 
     rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -93,13 +93,13 @@ through the ``converter`` keyword argument.
     ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
     SEMWEB_URL = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/semweb.context.jsonld"
 
-    converter = curies.chain([
+    base_converter = curies.chain([
         curies.load_jsonld_context(SEMWEB_URL),
         curies.get_obo_converter(),
     ])
 
     discovered_converter = curies.discover_from_rdf(
-        ONTOLOGY_URL, format="xml", converter=converter
+        ONTOLOGY_URL, format="xml", converter=base_converter
     )
 
 We reduced the number of putative URI prefixes in half in the following table. However, we can still identify
@@ -155,13 +155,13 @@ of two appearances of a URI prefix to reduce the most spurious false positives.
     ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
     SEMWEB_URL = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/semweb.context.jsonld"
 
-    converter = curies.chain([
+    base_converter = curies.chain([
         curies.load_jsonld_context(SEMWEB_URL),
         curies.get_obo_converter(),
     ])
 
     discovered_converter = curies.discover_from_rdf(
-        ONTOLOGY_URL, format="xml", converter=converter, cutoff=2
+        ONTOLOGY_URL, format="xml", converter=base_converter, cutoff=2
     )
 
 We have reduced the list to a manageable set of 9 putative URI prefixes in the following table.
@@ -183,7 +183,21 @@ ns9             ``urn:swrl#``
 Here are the calls to be made:
 
 - ``ns1`` represents the AEON vocabulary itself and should be given the ``aeon`` prefix.
-- ``ns2``, ``ns3``, ``ns6``, ``ns7`, and ``ns8`` are all false positives
+- ``ns2`` and ``ns3``` are all false positives
+- ``ns6``, ``ns7``, and ``ns8`` are a tricky case - they have a meaningful overlap that can't be easily
+  automatically detected (yet). In this case, it makes the most sense to add the shortest one manually
+  to the base converter with some unique name (don't use ``ns6`` as it will cause conflicts later), like in:
+
+  .. code-block:: python
+
+      base_converter = curies.chain([
+          curies.load_jsonld_context(SEMWEB_URL),
+          curies.get_obo_converter(),
+          curies.load_prefix_map({"confident_event_vivo_2021": "https://www.confident-conference.org/index.php/Event:VIVO_2021_"}),
+      ])
+
+  In reality, these are all part of the `ConfIDent Event <https://bioregistry.io/confident.event>`_ vocabulary,
+  which has the URI prefix ``https://www.confident-conference.org/index.php/Event:``.
 - ``ns4`` represents the `Conference Ontology <https://bioregistry.io/conference>`_ and
   should be given the ``conference`` prefix.
 - ``ns5`` represents the `Scientific Event Ontology (SEO) <https://bioregistry.io/seo>`_ and

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -1,0 +1,2 @@
+URI Prefix Discovery
+====================

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -1,3 +1,53 @@
 URI Prefix Discovery
 ====================
-.. todo:: write docs on :func:`curies.discover`
+.. warning::
+
+    This tutorial introduces tools that enable you to be a bad Semantic Citizen!
+    Use these tools at your own peril.
+
+Discovering URI Prefixes from an Ontology
+-----------------------------------------
+A common place where discovering URI prefixes is important is when working with new ontologies.
+
+.. code-block:: python
+
+    import rdflib
+    import curies
+    from tabulate import tabulate
+
+    ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
+    SEMWEB_URL = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/semweb.context.jsonld"
+
+
+    graph = rdflib.Graph()
+    graph.parse(ONTOLOGY_URL, format="xml")
+
+    # Load up some pre-registered context
+    converter = curies.chain(
+        [
+            curies.load_jsonld_context(SEMWEB_URL),
+            curies.get_obo_converter(),
+        ]
+    )
+
+    discovered_converter = curies.discover_from_rdf(converter, graph, delimiters="#/_", cutoff=5)
+    rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]
+    print(tabulate(rows, headers=["curie_prefix", "uri_prefix"], tablefmt="rst"))
+
+Results in:
+
+==============  ====================================================================
+curie_prefix    uri_prefix
+==============  ====================================================================
+ns1             ``http://purl.obolibrary.org/obo/AEON_``
+ns2             ``http://purl.obolibrary.org/obo/bfo/axiom/``
+ns3             ``https://github.com/tibonto/aeon/issues/``
+ns4             ``https://w3id.org/scholarlydata/ontology/conference-ontology.owl#``
+ns5             ``https://w3id.org/seo#``
+ns6             ``https://www.confident-conference.org/index.php/Event:VIVO_2021_``
+==============  ====================================================================
+
+.. note::
+
+    An alternative to discovering new prefixes is often to supplement your project-specific (extended)
+    prefix map with a comprehensive one, such as The Bioregistry.

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -11,26 +11,26 @@ A common place where discovering URI prefixes is important is when working with 
 
 .. code-block:: python
 
-    import rdflib
     import curies
     from tabulate import tabulate
 
     ONTOLOGY_URL = "https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl"
     SEMWEB_URL = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/semweb.context.jsonld"
 
-
-    graph = rdflib.Graph()
-    graph.parse(ONTOLOGY_URL, format="xml")
-
     # Load up some pre-registered context
-    converter = curies.chain(
-        [
-            curies.load_jsonld_context(SEMWEB_URL),
-            curies.get_obo_converter(),
-        ]
+    converter = curies.chain([
+        curies.load_jsonld_context(SEMWEB_URL),
+        curies.get_obo_converter(),
+    ])
+
+    discovered_converter = curies.discover_from_rdf(
+        converter,
+        graph=ONTOLOGY_URL,
+        graph_format="xml",
+        delimiters="#/_",
+        cutoff=5,
     )
 
-    discovered_converter = curies.discover_from_rdf(converter, graph, delimiters="#/_", cutoff=5)
     rows = [(record.prefix, f"``{record.uri_prefix}``") for record in discovered_converter.records]
     print(tabulate(rows, headers=["curie_prefix", "uri_prefix"], tablefmt="rst"))
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,6 +63,7 @@ for updating your code.
 
    tutorial
    reconciliation
+   discovery
    struct
    api
    services/index

--- a/src/curies/__init__.py
+++ b/src/curies/__init__.py
@@ -19,6 +19,7 @@ from .api import (
     write_jsonld_context,
     write_shacl,
 )
+from .discovery import discover, discovery_rdflib
 from .reconciliation import remap_curie_prefixes, remap_uri_prefixes, rewire
 from .sources import (
     get_bioregistry_converter,
@@ -56,4 +57,7 @@ __all__ = [
     "get_monarch_converter",
     "get_go_converter",
     "get_bioregistry_converter",
+    # discovery
+    "discover",
+    "discovery_rdflib",
 ]

--- a/src/curies/__init__.py
+++ b/src/curies/__init__.py
@@ -19,7 +19,7 @@ from .api import (
     write_jsonld_context,
     write_shacl,
 )
-from .discovery import discover, discovery_rdflib
+from .discovery import discover, discover_from_rdf
 from .reconciliation import remap_curie_prefixes, remap_uri_prefixes, rewire
 from .sources import (
     get_bioregistry_converter,
@@ -59,5 +59,5 @@ __all__ = [
     "get_bioregistry_converter",
     # discovery
     "discover",
-    "discovery_rdflib",
+    "discover_from_rdf",
 ]

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -178,6 +178,21 @@ def discover(
         map based on the discoveries.
     :returns:
         A converter with dummy prefixes
+
+    .. code-block:: python
+
+        >>> import curies
+
+        # Generate some example URIs
+        >>> uris = [f"http://ran.dom/{i:03}" for i in range(30)]
+
+        >>> discovered_converter = curies.discover(uris)
+        >>> discovered_converter.records
+        [Record(prefix="ns1", uri_prefix="http://ran.dom/")]
+
+        # Now, you can compress the URIs to dummy CURIEs
+        >>> discovered_converter.compress("http://ran.dom/002")
+        'ns1:002'
     """
     uri_prefix_to_luids = _get_uri_prefix_to_luids(
         converter=converter, uris=uris, delimiters=delimiters

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -1,7 +1,10 @@
 """Discovery new entries for a Converter."""
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Sequence, Set, Union
+from pathlib import PurePath
+from typing import IO, TYPE_CHECKING, Any, Iterable, Mapping, Optional, Sequence, Set, TextIO, Union
+
+from typing_extensions import Literal
 
 from curies import Converter, Record
 
@@ -14,27 +17,53 @@ __all__ = [
 ]
 
 
+GraphFormats = Literal["turtle", "xml", "n3", "nt", "trix"]
+GraphInput = Union[IO[bytes], TextIO, "rdflib.parser.InputSource", str, bytes, PurePath]
+
+
 def discover_from_rdf(
     converter: Converter,
-    graph: Union[str, "rdflib.Graph"],
-    graph_format: Optional[str] = None,
+    graph: Union[GraphInput, "rdflib.Graph"],
+    *,
+    format: Optional[GraphFormats] = None,
     **kwargs: Any,
 ) -> Converter:
-    """Discover new URI prefixes from an RDFLib triple store, wrapping :func:`curies.discover`."""
-    graph = _ensure_graph(graph, graph_format)
+    """Discover new URI prefixes from RDF content via :mod:`rdflib`.
+
+    :param converter:
+        A converter with pre-existing definitions. URI prefixes
+        are considered "new" if they can't already be validated by this converter
+    :param graph:
+        Either a pre-instantiated RDFlib graph, or an input type to the ``source``
+        keyword of :meth:`rdflib.Graph.parse`. This can be one of the following:
+
+        - A string or bytes representation of a URL
+        - A string, bytes, or Path representation of a local file
+        - An I/O object that can be read directly
+        - An open XML reader from RDFlib (:class:`rdflib.parser.InputSource`)
+    :param format: If ``graph`` is given as a URL or I/O object, this
+        is passed through to the ``format`` keyword of :meth:`rdflib.Graph.parse`.
+        If none is given, defaults to ``turtle``.
+    :param kwargs: Keyword arguments passed through to :func:`discover`
+    :returns:
+        A converter with dummy prefixes for URI prefixes appearing in the RDF
+        content (i.e., triples).
+    """
+    graph = _ensure_graph(graph, format)
     uris = set(_yield_uris(graph))
     return discover(converter, uris, **kwargs)
 
 
 def _ensure_graph(
-    graph: Union[str, "rdflib.Graph"], graph_format: Optional[str] = None
+    graph: Union[GraphInput, "rdflib.Graph"], format: Optional[GraphFormats] = None
 ) -> "rdflib.Graph":
-    if not isinstance(graph, str):
-        return graph
     import rdflib
 
+    if isinstance(graph, rdflib.Graph):
+        return graph
+
     rv = rdflib.Graph()
-    rv.parse(graph, format=graph_format)
+    rv.parse(graph, format=format)
     return rv
 
 
@@ -50,8 +79,9 @@ def _yield_uris(graph: "rdflib.Graph") -> Iterable[str]:
 def discover(
     converter: Converter,
     uris: Iterable[str],
+    *,
     delimiters: Sequence[str] = "#/",
-    cutoff: int = 30,
+    cutoff: Optional[int] = None,
     metaprefix: str = "ns",
 ) -> Converter:
     """Discover new URI prefixes.
@@ -70,27 +100,38 @@ def discover(
     :param cutoff:
         The number of unique URIs with a given prefix needed to call it
         as unique. This can be adjusted, but is initially high.
+
+        The cutoff can be set to 0 to recover all putative URI prefixes.
+        However, this comes with the risk of false positives.
     :param metaprefix:
         The beginning part of each dummy prefix, followed by a number. The default value
         is ``ns``, so dummy prefixes are named ``ns1``, ``ns2``, and so on.
     :returns:
         A converter with dummy prefixes
     """
-    counter = discover_helper(converter=converter, uris=uris, delimiters=delimiters)
-    records = []
-    record_number = 0
-    for uri_prefix, luids in sorted(counter.items()):
-        if len(luids) > cutoff:
-            record_number += 1
-            prefix = f"{metaprefix}{record_number}"
-            records.append(Record(prefix=prefix, uri_prefix=uri_prefix))
+    if cutoff is None:
+        cutoff = 0
+    uri_prefix_to_luids = _get_uri_prefix_to_luids(
+        converter=converter, uris=uris, delimiters=delimiters
+    )
+    uri_prefixes = [
+        uri_prefix
+        for uri_prefix, luids in sorted(uri_prefix_to_luids.items())
+        # If the cutoff is 5, and only 3 unique LUIDs with the URI prefix
+        # were identified, we're going to disregard this URI prefix.
+        if len(luids) >= cutoff
+    ]
+    records = [
+        Record(prefix=f"{metaprefix}{uri_prefix_index}", uri_prefix=uri_prefix)
+        for uri_prefix_index, uri_prefix in enumerate(uri_prefixes, start=1)
+    ]
     return Converter(records)
 
 
-def discover_helper(
+def _get_uri_prefix_to_luids(
     converter: Converter, uris: Iterable[str], delimiters: Sequence[str] = "#/"
 ) -> Mapping[str, Set[str]]:
-    """Discover new URI prefixes.
+    """Get a mapping from putative URI prefixes to corresponding putative local unique identifiers.
 
     :param converter:
         A converter with pre-existing definitions. URI prefixes
@@ -106,7 +147,7 @@ def discover_helper(
     :returns:
         A dictionary of putative URI prefixes to sets of putative local unique identifiers
     """
-    counter = defaultdict(set)
+    uri_prefix_to_luids = defaultdict(set)
     for uri in uris:
         if converter.is_uri(uri):
             continue
@@ -115,6 +156,6 @@ def discover_helper(
                 continue
             uri_prefix, luid = uri.rsplit(delimiter, maxsplit=1)
             if luid.isalnum():
-                counter[uri_prefix + delimiter].add(luid)
+                uri_prefix_to_luids[uri_prefix + delimiter].add(luid)
                 break
-    return dict(counter)
+    return dict(uri_prefix_to_luids)

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -15,6 +15,7 @@ __all__ = [
 
 
 def discovery_rdflib(converter: Converter, graph: "rdflib.Graph"):
+    """Discover new URI prefixes from an RDFLib triple store."""
     return discover(converter, set(_yield_uris(graph)))
 
 

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -1,0 +1,72 @@
+"""Discovery new entries for a Converter."""
+
+from typing import TYPE_CHECKING, Iterable
+
+from curies import Converter, Record
+from collections import defaultdict
+
+if TYPE_CHECKING:
+    import rdflib
+
+__all__ = [
+    "discover",
+    "discovery_rdflib",
+]
+
+
+def discovery_rdflib(converter: Converter, graph: "rdflib.Graph"):
+    return discover(converter, set(_yield_uris(graph)))
+
+
+def _yield_uris(graph: "rdflib.Graph") -> Iterable[str]:
+    import rdflib
+
+    for parts in graph.triples():
+        for part in parts:
+            if isinstance(part, rdflib.URIRef):
+                yield str(part)
+
+
+def discover(
+    converter: Converter,
+    uris: Iterable[str],
+    delimiters="#/",
+    cutoff: int = 30,
+    metaprefix: str = "ns",
+) -> Converter:
+    """Discover new URI prefixes.
+
+    :param converter: A converter with pre-existing definitions. URI prefixes
+        are considered "new" if they can't already be validated by this converter
+    :param uris: An iterable of URIs to search through. Will be taken as a set and
+        each unique entry is only considered once.
+    :param delimiters:
+        The delimiters considered between a putative URI prefix and putative
+        local unique identifier. By default, checks ``#`` first since this is
+        commonly used for URL fragments, then ``/`` since many URIs are constructed
+        with these.
+    :param cutoff: The number of unique URIs with a given prefix needed to call it
+        as unique. This can be adjusted, but is initially high.
+    :param metaprefix: The beginning part of each dummy prefix, followed by a number
+    :returns: A converter with dummy prefixes
+    """
+    counter = defaultdict(set)
+    for uri in uris:
+        if converter.is_uri(uri):
+            continue
+        for delimiter in delimiters:
+            if delimiter not in uri:
+                continue
+            uri_prefix, luid = uri.rsplit(delimiter, maxsplit=1)
+            if luid.isalnum():
+                counter[uri_prefix + delimiter].add(luid)
+                break
+    counter = dict(counter)
+    records = []
+    record_number = 0
+    for uri_prefix, luids in sorted(counter.items()):
+        if len(luids) > cutoff:
+            record_number += 1
+            prefix = f"{metaprefix}{record_number}"
+            records.append(Record(prefix=prefix, uri_prefix=uri_prefix))
+    return Converter(records)

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -22,7 +22,6 @@ GraphInput = Union[IO[bytes], TextIO, "rdflib.parser.InputSource", str, bytes, P
 
 
 def discover_from_rdf(
-    converter: Converter,
     graph: Union[GraphInput, "rdflib.Graph"],
     *,
     format: Optional[GraphFormats] = None,
@@ -30,9 +29,10 @@ def discover_from_rdf(
 ) -> Converter:
     """Discover new URI prefixes from RDF content via :mod:`rdflib`.
 
-    :param converter:
-        A converter with pre-existing definitions. URI prefixes
-        are considered "new" if they can't already be validated by this converter
+    This function works the same as :func:`discover`, but gets its URI list from
+    a triple store. See :func:`discover` for a more detailed explanation of how this
+    algorithm works.
+
     :param graph:
         Either a pre-instantiated RDFlib graph, or an input type to the ``source``
         keyword of :meth:`rdflib.Graph.parse`. This can be one of the following:
@@ -51,7 +51,7 @@ def discover_from_rdf(
     """
     graph = _ensure_graph(graph=graph, format=format)
     uris = set(_yield_uris(graph=graph))
-    return discover(converter, uris, **kwargs)
+    return discover(uris, **kwargs)
 
 
 def _ensure_graph(
@@ -77,26 +77,37 @@ def _yield_uris(*, graph: "rdflib.Graph") -> Iterable[str]:
 
 
 def discover(
-    converter: Converter,
     uris: Iterable[str],
     *,
     delimiters: Optional[Sequence[str]] = None,
     cutoff: Optional[int] = None,
     metaprefix: str = "ns",
+    converter: Optional[Converter] = None,
 ) -> Converter:
-    """Discover new URI prefixes.
+    """Discover new URI prefixes and construct a converter with a unique dummy CURIE prefix for each.
 
-    :param converter:
-        A converter with pre-existing definitions. URI prefixes
-        are considered "new" if they can't already be validated by this converter
     :param uris:
         An iterable of URIs to search through. Will be taken as a set and
         each unique entry is only considered once.
     :param delimiters:
-        The delimiters considered between a putative URI prefix and putative
-        local unique identifier. By default, checks ``#`` first since this is
-        commonly used for URL fragments, then ``/`` since many URIs are constructed
-        with these.
+        The character(s) that delimit a URI prefix from a local unique identifier.
+        If none given, defaults to using ``/``, ``#``, and ``_``. For example:
+
+        - ``/`` is the delimiter in ``https://www.ncbi.nlm.nih.gov/pubmed/37929212``, which separates
+          the URI prefix ``https://www.ncbi.nlm.nih.gov/pubmed/`` from the local unique identifier
+          `37929212 <https://www.ncbi.nlm.nih.gov/pubmed/37929212>`_ for the article
+          "New insights into osmobiosis and chemobiosis in tardigrades" in PubMed.
+        - ``#`` is the delimiter in ``http://www.w3.org/2000/01/rdf-schema#label``, which separates
+          the URI prefix ``http://www.w3.org/2000/01/rdf-schema#`` from the local unique identifier
+          `label <http://www.w3.org/2000/01/rdf-schema#label>`_ for the term "label" in the RDF Schema.
+          The ``#`` typically is used in a URL to denote a fragment and commonly appears in small semantic
+          web vocabularies that are shown as a single HTML page.
+        - ``_`` is the delimiter in ``http://purl.obolibrary.org/obo/GO_0032571``, which separates
+          the URI prefix ``http://purl.obolibrary.org/obo/GO_`` from the local unique identifier
+          `0032571 <http://purl.obolibrary.org/obo/GO_0032571>`_ for the term "response to vitamin K"
+          in the Gene Ontology
+
+        .. note:: The delimiter is itself a part of the URI prefix
     :param cutoff:
         If given, will require more than ``cutoff`` unique local unique identifiers
         associated with a given URI prefix to keep it.
@@ -108,11 +119,48 @@ def discover(
     :param metaprefix:
         The beginning part of each dummy prefix, followed by a number. The default value
         is ``ns``, so dummy prefixes are named ``ns1``, ``ns2``, and so on.
+    :param converter:
+        A converter with pre-existing definitions. URI prefixes
+        are considered "new" if they can't already be validated by this converter.
     :returns:
         A converter with dummy prefixes
+
+    This function is intended to be used in a "data science" workflow. Its goal is to enable a
+    data scientist to semi-interactively explore data (e.g., coming from an ontology, SSSOM, RDF)
+    that doesn't come with a complete (extended) prefix map and identify common URI prefixes.
+
+    It returns the discovered URI prefixes in a :class:`Converter` object with "dummy" CURIE prefixes.
+    This makes it possible to convert the URIs appearing in the data into CURIEs and therefore enables
+    their usage in places where CURIEs are expected.
+
+    However, it's suggested that after discovering URI prefixes, the data scientist more carefully
+    constructs a meaningful prefix map based on the discovered one. This might include some or all of the
+    following steps:
+
+    1. Replace dummy CURIE prefixes with meaningful ones
+    2. Remove spurious URI prefixes that appear but do not represent a semantic space. This happens often
+       due to using ``_`` as a delimiter or having a frequency cutoff of zero (see the parameters for this function).
+    3. Consider chaining a comprehensive extended prefix map such as the Bioregistry
+       (from :func:`curies.get_bioregistry_converter`) with onto the converter passed to this function
+       so pre-existing URI prefixes are not *re-discovered*.
+
+    Finally, you should save the prefix map that you create in a persistent place (i.e., inside a JSON file) such
+    that it can be reused.
+
+    This function implements the following algorithm that does the following for each URI:
+
+    1. For each delimiter (in the priority order they are given) check if the delimiter is present.
+    2. If it's present, split the URI into two parts based on rightmost appearance of the delimiter.
+    3. If the right part after splitting is all alphanumeric characters, save the URI prefix (with delimiter attached)
+    4. If a delimiter is successfully used to identify a URI prefix, don't check any of the following delimiters
+
+    After identifying putative URI prefixes, the second part of the algorithm does the following:
+
+    1. If a cutoff was provided, remove all putative URI prefixes for which there were fewer examples than the cutoff
+    2. Sort the URI prefixes lexicographically (i.e., with :func:`sorted`)
+    3. Assign a dummy CURIE prefix to each URI prefix, counting upwards from 1
+    4. Construct a converter from this prefix map and return it
     """
-    if cutoff is None:
-        cutoff = 0
     uri_prefix_to_luids = _get_uri_prefix_to_luids(
         converter=converter, uris=uris, delimiters=delimiters
     )
@@ -121,7 +169,7 @@ def discover(
         for uri_prefix, luids in sorted(uri_prefix_to_luids.items())
         # If the cutoff is 5, and only 3 unique LUIDs with the URI prefix
         # were identified, we're going to disregard this URI prefix.
-        if len(luids) >= cutoff
+        if cutoff is None or len(luids) >= cutoff
     ]
     records = [
         Record(prefix=f"{metaprefix}{uri_prefix_index}", uri_prefix=uri_prefix)
@@ -135,7 +183,10 @@ DEFAULT_DELIMITERS = ("#", "/", "_")
 
 
 def _get_uri_prefix_to_luids(
-    *, converter: Converter, uris: Iterable[str], delimiters: Optional[Sequence[str]] = None
+    *,
+    converter: Optional[Converter] = None,
+    uris: Iterable[str],
+    delimiters: Optional[Sequence[str]] = None,
 ) -> Mapping[str, Set[str]]:
     """Get a mapping from putative URI prefixes to corresponding putative local unique identifiers.
 
@@ -157,7 +208,7 @@ def _get_uri_prefix_to_luids(
         delimiters = DEFAULT_DELIMITERS
     uri_prefix_to_luids = defaultdict(set)
     for uri in uris:
-        if converter.is_uri(uri):
+        if converter is not None and converter.is_uri(uri):
             continue
         if uri.startswith("https://github.com") and "issues" in uri:
             # TODO it's not really the job of :mod:`curies` to incorporate special cases,

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -1,9 +1,9 @@
 """Discovery new entries for a Converter."""
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Iterable
 
 from curies import Converter, Record
-from collections import defaultdict
 
 if TYPE_CHECKING:
     import rdflib

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -105,12 +105,12 @@ def _ensure_graph(
 ) -> "rdflib.Graph":
     import rdflib
 
-    if isinstance(graph, rdflib.Graph):
-        return graph
+    if not isinstance(graph, rdflib.Graph):
+        _temp_graph = rdflib.Graph()
+        _temp_graph.parse(source=graph, format=format)
+        graph = _temp_graph
 
-    rv = rdflib.Graph()
-    rv.parse(source=graph, format=format)
-    return rv
+    return graph
 
 
 def _yield_uris(*, graph: "rdflib.Graph") -> Iterable[str]:

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -10,11 +10,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "discover",
-    "discovery_rdflib",
+    "discover_from_rdf",
 ]
 
 
-def discovery_rdflib(converter: Converter, graph: "rdflib.Graph", **kwargs: Any) -> Converter:
+def discover_from_rdf(converter: Converter, graph: "rdflib.Graph", **kwargs: Any) -> Converter:
     """Discover new URI prefixes from an RDFLib triple store."""
     uris = set(_yield_uris(graph))
     return discover(converter, uris, **kwargs)

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -88,9 +88,16 @@ def discover_from_rdf(
         A converter with dummy prefixes for URI prefixes appearing in the RDF
         content (i.e., triples).
     """
-    graph = _ensure_graph(graph=graph, format=format)
-    uris = set(_yield_uris(graph=graph))
+    uris = get_uris_from_rdf(graph=graph, format=format)
     return discover(uris, **kwargs)
+
+
+def get_uris_from_rdf(
+    graph: Union[GraphInput, "rdflib.Graph"], *, format: Optional[GraphFormats] = None
+) -> Set[str]:
+    """Get a set of URIs from a graph."""
+    graph = _ensure_graph(graph=graph, format=format)
+    return set(_yield_uris(graph=graph))
 
 
 def _ensure_graph(

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -20,7 +20,7 @@ def discover_from_rdf(
     graph_format: Optional[str] = None,
     **kwargs: Any,
 ) -> Converter:
-    """Discover new URI prefixes from an RDFLib triple store."""
+    """Discover new URI prefixes from an RDFLib triple store, wrapping :func:`curies.discover`."""
     graph = _ensure_graph(graph, graph_format)
     uris = set(_yield_uris(graph))
     return discover(converter, uris, **kwargs)
@@ -56,19 +56,25 @@ def discover(
 ) -> Converter:
     """Discover new URI prefixes.
 
-    :param converter: A converter with pre-existing definitions. URI prefixes
+    :param converter:
+        A converter with pre-existing definitions. URI prefixes
         are considered "new" if they can't already be validated by this converter
-    :param uris: An iterable of URIs to search through. Will be taken as a set and
+    :param uris:
+        An iterable of URIs to search through. Will be taken as a set and
         each unique entry is only considered once.
     :param delimiters:
         The delimiters considered between a putative URI prefix and putative
         local unique identifier. By default, checks ``#`` first since this is
         commonly used for URL fragments, then ``/`` since many URIs are constructed
         with these.
-    :param cutoff: The number of unique URIs with a given prefix needed to call it
+    :param cutoff:
+        The number of unique URIs with a given prefix needed to call it
         as unique. This can be adjusted, but is initially high.
-    :param metaprefix: The beginning part of each dummy prefix, followed by a number
-    :returns: A converter with dummy prefixes
+    :param metaprefix:
+        The beginning part of each dummy prefix, followed by a number. The default value
+        is ``ns``, so dummy prefixes are named ``ns1``, ``ns2``, and so on.
+    :returns:
+        A converter with dummy prefixes
     """
     counter = discover_helper(converter=converter, uris=uris, delimiters=delimiters)
     records = []
@@ -86,16 +92,19 @@ def discover_helper(
 ) -> Mapping[str, Set[str]]:
     """Discover new URI prefixes.
 
-    :param converter: A converter with pre-existing definitions. URI prefixes
+    :param converter:
+        A converter with pre-existing definitions. URI prefixes
         are considered "new" if they can't already be validated by this converter
-    :param uris: An iterable of URIs to search through. Will be taken as a set and
+    :param uris:
+        An iterable of URIs to search through. Will be taken as a set and
         each unique entry is only considered once.
     :param delimiters:
         The delimiters considered between a putative URI prefix and putative
         local unique identifier. By default, checks ``#`` first since this is
         commonly used for URL fragments, then ``/`` since many URIs are constructed
         with these.
-    :returns: A dictionary of putative URI prefixes to sets of putative local unique identifiers
+    :returns:
+        A dictionary of putative URI prefixes to sets of putative local unique identifiers
     """
     counter = defaultdict(set)
     for uri in uris:

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -1,7 +1,7 @@
 """Discovery new entries for a Converter."""
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, Set
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Sequence, Set, Union
 
 from curies import Converter, Record
 
@@ -14,10 +14,28 @@ __all__ = [
 ]
 
 
-def discover_from_rdf(converter: Converter, graph: "rdflib.Graph", **kwargs: Any) -> Converter:
+def discover_from_rdf(
+    converter: Converter,
+    graph: Union[str, "rdflib.Graph"],
+    graph_format: Optional[str] = None,
+    **kwargs: Any,
+) -> Converter:
     """Discover new URI prefixes from an RDFLib triple store."""
+    graph = _ensure_graph(graph, graph_format)
     uris = set(_yield_uris(graph))
     return discover(converter, uris, **kwargs)
+
+
+def _ensure_graph(
+    graph: Union[str, "rdflib.Graph"], graph_format: Optional[str] = None
+) -> "rdflib.Graph":
+    if not isinstance(graph, str):
+        return graph
+    import rdflib
+
+    rv = rdflib.Graph()
+    rv.parse(graph, format=graph_format)
+    return rv
 
 
 def _yield_uris(graph: "rdflib.Graph") -> Iterable[str]:

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -1,7 +1,7 @@
 """Discovery new entries for a Converter."""
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, Set
 
 from curies import Converter, Record
 
@@ -14,15 +14,16 @@ __all__ = [
 ]
 
 
-def discovery_rdflib(converter: Converter, graph: "rdflib.Graph") -> Converter:
+def discovery_rdflib(converter: Converter, graph: "rdflib.Graph", **kwargs: Any) -> Converter:
     """Discover new URI prefixes from an RDFLib triple store."""
-    return discover(converter, set(_yield_uris(graph)))
+    uris = set(_yield_uris(graph))
+    return discover(converter, uris, **kwargs)
 
 
 def _yield_uris(graph: "rdflib.Graph") -> Iterable[str]:
     import rdflib
 
-    for parts in graph.triples():
+    for parts in graph.triples((None, None, None)):
         for part in parts:
             if isinstance(part, rdflib.URIRef):
                 yield str(part)
@@ -51,6 +52,33 @@ def discover(
     :param metaprefix: The beginning part of each dummy prefix, followed by a number
     :returns: A converter with dummy prefixes
     """
+    counter = discover_helper(converter=converter, uris=uris, delimiters=delimiters)
+    records = []
+    record_number = 0
+    for uri_prefix, luids in sorted(counter.items()):
+        if len(luids) > cutoff:
+            record_number += 1
+            prefix = f"{metaprefix}{record_number}"
+            records.append(Record(prefix=prefix, uri_prefix=uri_prefix))
+    return Converter(records)
+
+
+def discover_helper(
+    converter: Converter, uris: Iterable[str], delimiters: Sequence[str] = "#/"
+) -> Mapping[str, Set[str]]:
+    """Discover new URI prefixes.
+
+    :param converter: A converter with pre-existing definitions. URI prefixes
+        are considered "new" if they can't already be validated by this converter
+    :param uris: An iterable of URIs to search through. Will be taken as a set and
+        each unique entry is only considered once.
+    :param delimiters:
+        The delimiters considered between a putative URI prefix and putative
+        local unique identifier. By default, checks ``#`` first since this is
+        commonly used for URL fragments, then ``/`` since many URIs are constructed
+        with these.
+    :returns: A dictionary of putative URI prefixes to sets of putative local unique identifiers
+    """
     counter = defaultdict(set)
     for uri in uris:
         if converter.is_uri(uri):
@@ -62,11 +90,4 @@ def discover(
             if luid.isalnum():
                 counter[uri_prefix + delimiter].add(luid)
                 break
-    records = []
-    record_number = 0
-    for uri_prefix, luids in sorted(counter.items()):
-        if len(luids) > cutoff:
-            record_number += 1
-            prefix = f"{metaprefix}{record_number}"
-            records.append(Record(prefix=prefix, uri_prefix=uri_prefix))
-    return Converter(records)
+    return dict(counter)

--- a/src/curies/discovery.py
+++ b/src/curies/discovery.py
@@ -1,7 +1,7 @@
 """Discovery new entries for a Converter."""
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Sequence
 
 from curies import Converter, Record
 
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def discovery_rdflib(converter: Converter, graph: "rdflib.Graph"):
+def discovery_rdflib(converter: Converter, graph: "rdflib.Graph") -> Converter:
     """Discover new URI prefixes from an RDFLib triple store."""
     return discover(converter, set(_yield_uris(graph)))
 
@@ -31,7 +31,7 @@ def _yield_uris(graph: "rdflib.Graph") -> Iterable[str]:
 def discover(
     converter: Converter,
     uris: Iterable[str],
-    delimiters="#/",
+    delimiters: Sequence[str] = "#/",
     cutoff: int = 30,
     metaprefix: str = "ns",
 ) -> Converter:
@@ -62,7 +62,6 @@ def discover(
             if luid.isalnum():
                 counter[uri_prefix + delimiter].add(luid)
                 break
-    counter = dict(counter)
     records = []
     record_number = 0
     for uri_prefix, luids in sorted(counter.items()):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,13 +15,26 @@ class TestDiscovery(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Set up the test case with a dummy converter."""
-        cls.converter = Converter([])
+        cls.converter = Converter(
+            [Record(prefix="GO", uri_prefix="http://purl.obolibrary.org/obo/GO_")]
+        )
 
     def test_simple(self):
         """Test a simple case of discovering URI prefixes."""
         uris = [f"http://ran.dom/{i:03}" for i in range(30)]
+        uris.append("http://purl.obolibrary.org/obo/GO_0001234")
+
         converter = discover(self.converter, uris, cutoff=3)
         self.assertEqual([Record(prefix="ns1", uri_prefix="http://ran.dom/")], converter.records)
+        self.assertEqual("ns1:001", converter.compress("http://ran.dom/001"))
+        self.assertIsNone(
+            converter.compress("http://purl.obolibrary.org/obo/GO_0001234"),
+            msg="discovered converter should not inherit reference converter's definitions",
+        )
 
         converter = discover(self.converter, uris, cutoff=50)
         self.assertEqual([], converter.records)
+        self.assertIsNone(
+            converter.compress("http://ran.dom/001"),
+            msg="cutoff was high, so discovered converter should not detect `http://ran.dom/`",
+        )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,27 @@
+"""Test discovering a prefix map from a list of URIs."""
+
+import unittest
+from typing import ClassVar
+
+from curies.discovery import discover
+from curies import Converter, Record
+
+
+class TestDiscovery(unittest.TestCase):
+    """Test discovery of URI prefixes."""
+
+    converter: ClassVar[Converter]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up the test case with a dummy converter."""
+        cls.converter = Converter([])
+
+    def test_simple(self):
+        """Test a simple case of discovering URI prefixes."""
+        uris = [f"http://ran.dom/{i:03}" for i in range(30)]
+        converter = discover(self.converter, uris, cutoff=3)
+        self.assertEqual([Record(prefix="ns1", uri_prefix="http://ran.dom/")], converter.records)
+
+        converter = discover(self.converter, uris, cutoff=50)
+        self.assertEqual([], converter.records)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 import rdflib
 
 from curies import Converter, Record
-from curies.discovery import discover, discovery_rdflib
+from curies.discovery import discover, discover_from_rdf
 
 
 class TestDiscovery(unittest.TestCase):
@@ -60,7 +60,7 @@ class TestDiscovery(unittest.TestCase):
                 )
             )
 
-        converter = discovery_rdflib(self.converter, graph)
+        converter = discover_from_rdf(self.converter, graph)
         self.assertEqual([Record(prefix="ns1", uri_prefix="http://ran.dom/")], converter.records)
         self.assertEqual("ns1:001", converter.compress("http://ran.dom/001"))
         self.assertIsNone(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -30,7 +30,7 @@ class TestDiscovery(unittest.TestCase):
         uris = [f"http://ran.dom/{i:03}" for i in range(30)]
         uris.append("http://purl.obolibrary.org/obo/GO_0001234")
 
-        converter = discover(self.converter, uris, cutoff=3)
+        converter = discover(uris, cutoff=3, converter=self.converter)
         self.assertEqual([Record(prefix="ns1", uri_prefix="http://ran.dom/")], converter.records)
         self.assertEqual("ns1:001", converter.compress("http://ran.dom/001"))
         self.assertIsNone(
@@ -38,7 +38,7 @@ class TestDiscovery(unittest.TestCase):
             msg="discovered converter should not inherit reference converter's definitions",
         )
 
-        converter = discover(self.converter, uris, cutoff=50)
+        converter = discover(uris, cutoff=50, converter=self.converter)
         self.assertEqual([], converter.records)
         self.assertIsNone(
             converter.compress("http://ran.dom/001"),
@@ -64,7 +64,7 @@ class TestDiscovery(unittest.TestCase):
                 )
             )
 
-        converter = discover_from_rdf(self.converter, graph)
+        converter = discover_from_rdf(graph, converter=self.converter)
         self.assertEqual([Record(prefix="ns1", uri_prefix="http://ran.dom/")], converter.records)
         self.assertEqual("ns1:001", converter.compress("http://ran.dom/001"))
         self.assertIsNone(
@@ -76,7 +76,6 @@ class TestDiscovery(unittest.TestCase):
     def test_remote(self):
         """Test parsing AEON."""
         converter = discover_from_rdf(
-            converter=Converter([]),
             graph="https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl",
             format="xml",
         )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -7,6 +7,7 @@ import rdflib
 
 from curies import Converter, Record
 from curies.discovery import discover, discover_from_rdf
+from tests.constants import SLOW
 
 
 class TestDiscovery(unittest.TestCase):
@@ -18,7 +19,10 @@ class TestDiscovery(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up the test case with a dummy converter."""
         cls.converter = Converter(
-            [Record(prefix="GO", uri_prefix="http://purl.obolibrary.org/obo/GO_")]
+            [
+                Record(prefix="GO", uri_prefix="http://purl.obolibrary.org/obo/GO_"),
+                Record(prefix="rdfs", uri_prefix=str(rdflib.RDFS._NS)),
+            ]
         )
 
     def test_simple(self):
@@ -67,3 +71,13 @@ class TestDiscovery(unittest.TestCase):
             converter.compress("http://purl.obolibrary.org/obo/GO_0001234"),
             msg="discovered converter should not inherit reference converter's definitions",
         )
+
+    @SLOW
+    def test_remote(self):
+        """Test parsing AEON."""
+        converter = discover_from_rdf(
+            converter=Converter([]),
+            graph="https://raw.githubusercontent.com/tibonto/aeon/main/aeon.owl",
+            format="xml",
+        )
+        self.assertIn("http://purl.obolibrary.org/obo/AEON_", converter.reverse_prefix_map)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -3,8 +3,8 @@
 import unittest
 from typing import ClassVar
 
-from curies.discovery import discover
 from curies import Converter, Record
+from curies.discovery import discover
 
 
 class TestDiscovery(unittest.TestCase):


### PR DESCRIPTION
This PR adds a workflow that iterates through a list of URIs and tries to discovery new common URI prefixes. Docs: https://curies.readthedocs.io/en/discovery/discovery.html

## Algorithm

It follows this basic algorithm given by @matentzn:

1. Define a prioritized list of delimiters (e.g., `#`, `/`)
2. For each URI, for each delimiter:
   1. If the delimiter isn't present, continue
   2. Right split the URI based on the delimiter
   3. If the part after the split is at least one alphanumeric character, save the URI prefix as putative
3. Apply a cutoff for putative URI prefixes that are of a certain frequency
4. Create dummy CURIE prefixes (`ns1`, `ns2`, ...) for each discovered URI prefix
5. Return a Converter with the dummy CURIE prefix / discovered URI prefixes that can be chained onto a converter (don't modify converters in place, ever!)

## Demo

Assume you have some ontology with randomly generated URIs with the prefix `http://ran.dom/` (but you don't know this ahead of time). You can use the `curies.discover` function to create a converter that has a dummy CURIE prefix `ns1` for this URI prefix.

```python
import curies

converter = curies.get_obo_converter()

# URIs can come from wherever
uris = [f"http://ran.dom/{i:03}" for i in range(30)]

discovered_converter = curies.discover(uris, converter=converter)
>>> discovered_converter.records
[Record(prefix="ns1", uri_prefix="http://ran.dom/")]

# Now, you can chain your extra converter together with your first one
augmented_converter = curies.chain([converter, discovered_converter])

# Compression works for existing and for new URI prefix definitions
augmented_converter.compress("http://purl.obolibrary.org/obo/GO_1234567")
>>> 'GO:1234567'
augmented_converter.compress("http://ran.dom/002")
>>> 'ns1:002'
```


## Use Cases

1. OAEI runs a few competitions on generated ontologies with generated term IDs. To drive adoption of SSSOM in their matchers, there needs to be a zero-barrier solution to generating SSSOM files even in cases where there are no “real” ontologies involved.
2. Some companies are interested to using SSSOM, but have proprietary URIs in their ontologies and aren't well-versed in practical semantics. Again, they want to extract SSSOM files without the distraction of having to write prefix maps.
